### PR TITLE
Improve message dispatching & small refactorings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
- use std::{
+use std::{
     collections::{HashMap, HashSet},
     ops::Deref,
     str::FromStr,


### PR DESCRIPTION
Hi, 

I made some small improvements dispatching messages to a listener. Basically:
- Drop locks early, especially drop them before the dispatch ie. on_receive call
- Dispatch is done on a separate task so that a slow listener does not slow down. 
- Todo to handle the connection drop case correctly.

Cheers, 

Jan