### PR TITLE
Inplement fallback for getting UAttributes from payload if MQTT5 is not supported

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -361,7 +361,8 @@ impl UPClientMqtt {
                     .get_int(mqtt::PropertyCode::SubscriptionIdentifier);
 
                 // Get attributes from mqtt header.
-                let umessage = if msg.properties().is_empty() {
+                let umessage = if UPClientMqtt::get_uattributes_from_mqtt_properties(msg.properties()).is_err() {
+                    debug!("empty properties");
                     protobuf::Message::parse_from_bytes(msg.payload()).unwrap()
                 } else {
                     let uattributes = {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -361,25 +361,30 @@ impl UPClientMqtt {
                     .get_int(mqtt::PropertyCode::SubscriptionIdentifier);
 
                 // Get attributes from mqtt header.
-                let uattributes = {
-                    match UPClientMqtt::get_uattributes_from_mqtt_properties(msg.properties()) {
-                        Ok(uattributes) => uattributes,
-                        Err(e) => {
-                            warn!("Unable to get UAttributes from mqtt properties: {}", e);
-                            continue;
+                let umessage = if msg.properties().is_empty() {
+                    protobuf::Message::parse_from_bytes(msg.payload()).unwrap()
+                } else {
+                    let uattributes = {
+                        match UPClientMqtt::get_uattributes_from_mqtt_properties(msg.properties()) {
+                            Ok(uattributes) => uattributes,
+                            Err(e) => {
+                                warn!("Unable to get UAttributes from mqtt properties: {}", e);
+                                continue;
+                            }
                         }
+                    };
+    
+                    let payload = msg.payload();
+                    let upayload = payload.to_vec();
+    
+                    // Create UMessage from UAttributes and UPayload.
+                    UMessage {
+                        attributes: Some(uattributes).into(),
+                        payload: Some(upayload.into()),
+                        ..Default::default()
                     }
                 };
-
-                let payload = msg.payload();
-                let upayload = payload.to_vec();
-
-                // Create UMessage from UAttributes and UPayload.
-                let umessage = UMessage {
-                    attributes: Some(uattributes).into(),
-                    payload: Some(upayload.into()),
-                    ..Default::default()
-                };
+                
 
                 let topic_map_read = topic_map.read().await;
                 let subscription_map_read = subscription_map.read().await;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -360,11 +360,9 @@ impl UPClientMqtt {
                     .properties()
                     .get_int(mqtt::PropertyCode::SubscriptionIdentifier);
 
-                info!("this is the correct version");
                 // Get attributes from mqtt header.
                 let umessage = if UPClientMqtt::get_uattributes_from_mqtt_properties(msg.properties()).is_err() {
                     debug!("empty properties");
-                    panic!();
                     protobuf::Message::parse_from_bytes(msg.payload()).unwrap()
                 } else {
                     let uattributes = {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -360,9 +360,11 @@ impl UPClientMqtt {
                     .properties()
                     .get_int(mqtt::PropertyCode::SubscriptionIdentifier);
 
+                info!("this is the correct version");
                 // Get attributes from mqtt header.
                 let umessage = if UPClientMqtt::get_uattributes_from_mqtt_properties(msg.properties()).is_err() {
                     debug!("empty properties");
+                    panic!();
                     protobuf::Message::parse_from_bytes(msg.payload()).unwrap()
                 } else {
                     let uattributes = {


### PR DESCRIPTION
This fix enables using MQTT3.1 messages and still building a full UMessage from the MQTT message. This is particularly important for enabling UProtocol on systems that run threadX beacuse there is currently no MQTT5 capable client that runs on it.