### PR TITLE
Use dedicated function for connecting to broker

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -142,7 +142,7 @@ jobs:
       - uses: taiki-e/install-action@nextest
       - name: Run cargo nextest
         run: |
-          cargo nextest run --message-format libtest-json-plus ${{ matrix.feature-flags }} > testresults${{ matrix.feature-flags }}.json
+          cargo nextest run --no-fail-fast --retries 1 --message-format libtest-json-plus ${{ matrix.feature-flags }} > testresults${{ matrix.feature-flags }}.json
 
       - name: Upload all-features test results artifact
         id: test_results

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ name = "up-transport-mqtt5"
 readme = "README.md"
 repository = "https://github.com/eclipse-uprotocol/up-client-mqtt5-rust"
 rust-version = "1.81"
-version = "0.2.0"
+version = "0.3.0-SNAPSHOT"
 
 [features]
 default = ["cli"]

--- a/examples/publisher_example.rs
+++ b/examples/publisher_example.rs
@@ -44,6 +44,8 @@ async fn main() -> Result<(), UStatus> {
     )
     .await?;
 
+    client.connect().await?;
+
     loop {
         tokio::time::sleep(std::time::Duration::from_secs(1)).await;
         let current_time = SystemTime::now()

--- a/examples/subscriber_example.rs
+++ b/examples/subscriber_example.rs
@@ -58,6 +58,8 @@ async fn main() -> Result<(), UStatus> {
     )
     .await?;
 
+    client.connect().await?;
+
     let listener = Arc::new(LoggingListener {});
 
     info!(

--- a/tests/publish_subscribe.rs
+++ b/tests/publish_subscribe.rs
@@ -21,6 +21,10 @@ async fn test_publish_and_subscribe() {
     let subscriber = common::create_up_transport_mqtt("Subscriber")
         .await
         .expect("failed to create transport at receiving end");
+    subscriber
+        .connect()
+        .await
+        .expect("failed to connect subscriber to broker");
     let source_filter =
         UUri::from_str("//Publisher/A8000/2/FFFF").expect("Failed to create source filter");
     subscriber
@@ -31,6 +35,11 @@ async fn test_publish_and_subscribe() {
     let publisher = common::create_up_transport_mqtt("Publisher")
         .await
         .expect("failed to create transport at sending end");
+    publisher
+        .connect()
+        .await
+        .expect("failed to connect publisher to broker");
+
     let source = UUri::from_str("//Publisher/A8000/2/8A50").unwrap();
     let message_to_send = UMessageBuilder::publish(source)
         .build_with_payload(payload, up_rust::UPayloadFormat::UPAYLOAD_FORMAT_TEXT)


### PR DESCRIPTION
The functionalilty for connecting to the broker has been moved from Mqtt5Transport::new to dedicated function Mqtt5Transport::connect.

This allows client code to implement any particular kind of retry logic when starting up the transport.