### PR TITLE
Subscribtion recreation

### DIFF
--- a/src/mqtt_client.rs
+++ b/src/mqtt_client.rs
@@ -24,7 +24,6 @@ use backon::Retryable;
 #[cfg(feature = "cli")]
 use clap::Args;
 use log::{debug, trace};
-use paho_mqtt::Error;
 use up_rust::{UCode, UStatus};
 
 use crate::{listener_registry::SubscribedTopicProvider, SubscriptionIdentifier};
@@ -429,7 +428,7 @@ impl PahoBasedMqttClientOperations {
     async fn recreate_subscriptions(
         mqtt_client: Arc<paho_mqtt::AsyncClient>,
         subscribed_topics: HashMap<SubscriptionIdentifier, String>,
-    ) -> Result<(), Error> {
+    ) -> Result<(), paho_mqtt::Error> {
         for (subscription_id, topic_filter) in subscribed_topics {
             // we ignore any potential errors when creating the properties because the worst
             // thing that can happen is that we subscribe without a subscription identifier

--- a/src/mqtt_client.rs
+++ b/src/mqtt_client.rs
@@ -452,8 +452,6 @@ impl PahoBasedMqttClientOperations {
                 );
             }
         }
-        SUBSCRIPTION_RECREATION_IN_PROGRESS_IN_PROGRESS
-            .store(false, std::sync::atomic::Ordering::Release);
         Ok(())
     }
 }
@@ -541,6 +539,7 @@ impl MqttClientOperations for PahoBasedMqttClientOperations {
                                 .with_min_delay(Duration::from_millis(500))
                                 .with_max_delay(Duration::from_secs(10))
                                 .without_max_times();
+                            // We can ignore the result since we will retry indefinitely
                             let _ = (|| {
                                 Self::recreate_subscriptions(
                                     mqtt_client.clone(),
@@ -553,6 +552,8 @@ impl MqttClientOperations for PahoBasedMqttClientOperations {
                                 true
                             })
                             .await;
+                            SUBSCRIPTION_RECREATION_IN_PROGRESS_IN_PROGRESS
+                                .store(false, std::sync::atomic::Ordering::Release);
                         });
                     }
                 }

--- a/src/mqtt_client.rs
+++ b/src/mqtt_client.rs
@@ -573,7 +573,7 @@ impl MqttClientOperations for PahoBasedMqttClientOperations {
             .load(std::sync::atomic::Ordering::Relaxed)
         {
             return Err(UStatus::fail_with_code(
-                UCode::INTERNAL,
+                UCode::UNAVAILABLE,
                 "Failed to publish since there is a subscription recreation running",
             ));
         }
@@ -590,7 +590,7 @@ impl MqttClientOperations for PahoBasedMqttClientOperations {
             .load(std::sync::atomic::Ordering::Relaxed)
         {
             return Err(UStatus::fail_with_code(
-                UCode::INTERNAL,
+                UCode::UNAVAILABLE,
                 "Failed to subscribe since there is a subscription recreation running",
             ));
         }


### PR DESCRIPTION
@sophokles73 , @PLeVasseur : Can you take a look?

Idea is to do the subscription recreation within a new task and use backoff-retry until they are completely restored. 
