### PR TITLE
Improve CI job for running tests

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,6 @@
+[profile.ci]
+fail-fast = false
+leak-timeout = "200ms"
+
+[profile.ci.junit]
+path = "nextest-results.xml"

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -31,9 +31,6 @@ on:
       test_results_url:
         description: "URL of the test results artifact"
         value: ${{ jobs.nextest.outputs.test_results_url }}
-      doctest_results_url:
-        description: "URL of the doctest results artifact"
-        value: ${{ jobs.doctest.outputs.test_results_url }}
   workflow_dispatch:
 
 concurrency:
@@ -138,11 +135,21 @@ jobs:
         with: 
           toolchain: ${{ env.RUST_TOOLCHAIN }}
       - uses: Swatinem/rust-cache@v2
+      # install tool to convert cargo's JSON test output to JUNIT format
+      - run: |
+          cargo install cargo2junit
       # Using nextest because it's faster than built-in test
       - uses: taiki-e/install-action@nextest
       - name: Run cargo nextest
         run: |
-          cargo nextest run --no-fail-fast --retries 1 --message-format libtest-json-plus ${{ matrix.feature-flags }} > testresults${{ matrix.feature-flags }}.json
+          cargo nextest run ${{ matrix.feature-flags }} --profile ci
+      - name: Run doctests
+        run: |
+          # we use tee to let cargo test print to the console
+          RUSTC_BOOTSTRAP=1 cargo test --doc ${{ matrix.feature-flags }} -- -Z unstable-options --format json --report-time | tee target/doctest-results.json
+          # write output to same directory as the one used by cargo nextest in order
+          # to flatten the directory hierarchy when uploading the test results
+          cat target/doctest-results.json | cargo2junit > target/nextest/ci/doctest-results.xml
 
       - name: Upload all-features test results artifact
         id: test_results
@@ -150,28 +157,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: test-results
-          path: testresults--all-features.json
-
-  doctest:
-    # Run doctests separately, as nextest doesn't yet (https://github.com/nextest-rs/nextest/issues/16)
-    outputs:
-      test_results_url: ${{ steps.doctest_results.outputs.artifact-url }}
-    runs-on: ubuntu-latest
-    env:
-      RUSTDOCFLAGS: -Dwarnings
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: "recursive"
-      - uses: dtolnay/rust-toolchain@master
-        with: 
-          toolchain: ${{ env.RUST_TOOLCHAIN }}
-      - name: Run doc tests
-        run: |
-          RUSTC_BOOTSTRAP=1 cargo test --doc --all-features -- -Z unstable-options --format json --report-time > doctestresults--all-features.json
-      - name: Upload doctest results artifact
-        id: doctest_results
-        uses: actions/upload-artifact@v4
-        with:
-          name: doctest-results
-          path: doctestresults--all-features.json
+          # this will include the nextest and doctest result files in the archive's root folder
+          path: target/nextest/ci/*-results.xml


### PR DESCRIPTION
Adapted the execution of cargo nextest to use a CI specific profile and
produce test results in JUnit format.
Included the running of the doctests in the same job that runs cargo
nextest so that the doctests are also executed for all relevant
feature combinations.
Merged the test results into a single archive so that all results are
part of the archive that is attached to releases.