### PR TITLE
Conditionally build tests requiring Docker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1598,7 +1598,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1611,7 +1611,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.2",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2054,9 +2054,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.44.1"
+version = "1.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f382da615b842244d4b8738c82ed1275e6c5dd90c459a30941cd07080b06c91a"
+checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
 dependencies = [
  "backtrace",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,9 @@ tokio = { version = "1.44", default-features = false, features = [
 ] }
 up-rust = { version = "0.5.0", default-features = false }
 
+[build-dependencies]
+testcontainers = { version = "0.23", features = ["blocking"] }
+
 [dev-dependencies]
 env_logger = { version = "0.11.7" }
 mockall = { version = "0.13" }
@@ -87,3 +90,10 @@ required-features = ["cli"]
 
 [package.metadata.docs.rs]
 all-features = true
+
+[lints.rust]
+# The build.rs script determines if Docker is available on the build
+# platform and adds the 'docker_available' cfg flag accordingly.
+# Tests using #[cfg(docker_available)] will then only be compiled (and run)
+# if Docker is actually available on the platform.
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(docker_available)'] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ testcontainers = { version = "0.23", features = ["blocking"] }
 env_logger = { version = "0.11.7" }
 mockall = { version = "0.13" }
 test-case = { version = "3.3" }
-tokio = { version = "1.44", default-features = false, features = [
+tokio = { version = "1.44.2", default-features = false, features = [
     "macros",
     "rt",
     "rt-multi-thread",

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,31 @@
+/********************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+use testcontainers::{runners::SyncRunner, GenericImage};
+
+pub fn main() {
+    // Try to pull the Mosquitto MQTT broker container image which will be needed to
+    // run integration tests.
+    if let Err(err) = GenericImage::new("eclipse-mosquitto", "2.0").pull_image() {
+        eprintln!("Docker is not available on build platform: {err}");
+    } else {
+        // Tests using #[cfg(docker_available)] will only be compiled (and run)
+        // if Docker is actually available on the platform (as determined by the
+        // testcontainers crate).
+        eprintln!("Docker is available on build platform");
+        println!("cargo::rustc-cfg=docker_available");
+    }
+    // we should only need to determine once, if Docker is available
+    // triggering re-execution of this check should always be possible
+    // by means of doing a cargo clean ...
+    println!("cargo::rerun-if-changed=build.rs");
+}

--- a/deny.toml
+++ b/deny.toml
@@ -18,7 +18,9 @@
 allow = [
     "Apache-2.0",
     "BSD-2-Clause",
+    "BSD-3-Clause",
     "EPL-2.0",
+    "ISC",
     "MIT",
     # Unicode-3.0 is not (yet) on the Eclipse Foundation's list of approved licenses
     # however, all of its predecessors are, thus we assume that 3.0 is also ok to use
@@ -33,4 +35,5 @@ wildcards = "deny"
 skip-tree = [
     { crate = "windows-sys", reason = "a foundational crate for many that bumps far too frequently to ever have a shared version" },
     { crate = "getrandom@0.2.15", reason = "an outdated version that is still used by some other crates we depend on" },
+    { crate = "testcontainers", reason = "this crate (and its deps) is only used for testing" },
 ]

--- a/src/mqtt_client.rs
+++ b/src/mqtt_client.rs
@@ -304,10 +304,10 @@ impl PahoBasedMqttClientOperations {
     ///
     /// # Arguments
     /// * `options` - Configuration for the MQTT client. These configuration options
-    ///               are getting stored with the client and used again when
-    ///               reestablishing a lost connection to the broker.
+    ///   are getting stored with the client and used again when reestablishing a lost
+    ///   connection to the broker.
     /// * `subscribed_topic_provider` - A component that knows about the topic filters for which
-    ///                                 listeners have been registered.
+    ///   listeners have been registered.
     ///
     /// # Returns
     ///

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -51,7 +51,7 @@ pub async fn create_up_transport_mqtt<S: Into<String>>(
 pub async fn start_mosquitto() -> (ContainerAsync<GenericImage>, u16) {
     const MOSQUITTO_CONTAINER_PORT: u16 = 1883;
 
-    let container = GenericImage::new("eclipse-mosquitto", "2.0.21")
+    let container = GenericImage::new("eclipse-mosquitto", "2.0")
         .with_exposed_port(ContainerPort::Tcp(MOSQUITTO_CONTAINER_PORT))
         // mosquitto seems to write to stderr
         .with_wait_for(WaitFor::message_on_stderr(" running"))

--- a/tests/publish_subscribe.rs
+++ b/tests/publish_subscribe.rs
@@ -19,6 +19,8 @@ use up_rust::{MockUListener, UMessageBuilder, UTransport, UUri};
 mod common;
 
 #[tokio::test]
+#[cfg(docker_available)]
+// This test requires Docker to run the Mosquitto MQTT broker.
 async fn test_publish_and_subscribe() {
     env_logger::init();
 


### PR DESCRIPTION
Some of the integration tests require Docker to start a Mosquitto
broker. These tests fail if Docker is not available on the build
platform.

A build.rs script has been added which checks if Docker is available
and allows tests to be conditionally built (and run) if that is indeed
the case.

This addresses #50