### PR TITLE
Bump deps and fix nightly job

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -352,9 +352,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ba6d68e24814cb8de6bb986db8222d3a027d15872cabc0d18817bc3c0e4471"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -456,9 +456,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.7"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3716d7a920fb4fac5d84e9d4bce8ceb321e9414b4409da61b07b75c1e3d0697"
+checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1235,9 +1235,9 @@ checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "paho-mqtt"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cc4a07a3f748f8272b26f253416c0d9452c423910c563d7633949f43df9efea"
+checksum = "852a41a43e1fab8cc7d263fa2e475da52aed2b06314424b819cade0cfb085cf9"
 dependencies = [
  "async-channel",
  "crossbeam-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ clap = { version = "4.5", default-features = false, features = [
 ], optional = true }
 futures = { version = "0.3" }
 log = { version = "0.4" }
-paho-mqtt = { version = "0.13.1", features = ["vendored-ssl"] }
+paho-mqtt = { version = "0.13.2", features = ["vendored-ssl"] }
 protobuf = { version = "3.7.2" }
 tokio = { version = "1.44", default-features = false, features = [
     "rt",
@@ -65,7 +65,7 @@ up-rust = { version = "0.5.0", default-features = false }
 testcontainers = { version = "0.23", features = ["blocking"] }
 
 [dev-dependencies]
-env_logger = { version = "0.11.7" }
+env_logger = { version = "0.11.8" }
 mockall = { version = "0.13" }
 test-case = { version = "3.3" }
 tokio = { version = "1.44.2", default-features = false, features = [

--- a/tests/publish_subscribe.rs
+++ b/tests/publish_subscribe.rs
@@ -13,13 +13,12 @@
 
 use std::{str::FromStr, sync::Arc, time::Duration};
 
-use tokio::sync::Notify;
 use up_rust::{MockUListener, UMessageBuilder, UTransport, UUri};
 
 mod common;
 
 #[tokio::test]
-#[cfg(docker_available)]
+#[cfg_attr(not(docker_available), ignore)]
 // This test requires Docker to run the Mosquitto MQTT broker.
 async fn test_publish_and_subscribe() {
     env_logger::init();
@@ -29,7 +28,7 @@ async fn test_publish_and_subscribe() {
 
     let payload = "test_payload";
     let expected_payload = payload.to_owned();
-    let message_received = Arc::new(Notify::new());
+    let message_received = Arc::new(tokio::sync::Notify::new());
     let message_received_clone = message_received.clone();
     let mut listener = MockUListener::new();
     listener.expect_on_receive().once().return_once(move |msg| {


### PR DESCRIPTION
Using the ignore attribute allows us to write all tests as if Docker
were available. This also means that cargo build does not complain
about unused imports and code if Docker is not available when running
the tests.