### PR TITLE
Improve incoming message handling for subscriptions with a sub_id 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2206,6 +2206,7 @@ dependencies = [
  "mockall",
  "paho-mqtt",
  "protobuf",
+ "slab",
  "test-case",
  "testcontainers",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ futures = { version = "0.3" }
 log = { version = "0.4" }
 paho-mqtt = { version = "0.13.2", features = ["vendored-ssl"] }
 protobuf = { version = "3.7.2" }
+slab = { version = "0.4.9" }
 tokio = { version = "1.44", default-features = false, features = [
     "rt",
     "rt-multi-thread",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,3 +98,9 @@ all-features = true
 # Tests using #[cfg(docker_available)] will then only be compiled (and run)
 # if Docker is actually available on the platform.
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(docker_available)'] }
+
+[lints.clippy]
+ ignored_unit_patterns = "warn"
+ or_fun_call = "warn"
+ as_conversions = "warn"
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -163,7 +163,7 @@ impl TransportMode {
     ) -> Result<String, UUriError> {
         match self {
             // [impl->dsn~up-transport-mqtt5-e2e-topic-names~1]
-            TransportMode::InVehicle => {
+            Self::InVehicle => {
                 let mut topic = String::new();
                 topic.push_str(&Self::uri_to_e2e_mqtt_topic(source, fallback_authority));
                 if let Some(uri) = sink {
@@ -173,8 +173,13 @@ impl TransportMode {
                 Ok(topic)
             }
             // [impl->dsn~up-transport-mqtt5-d2d-topic-names~1]
-            TransportMode::OffVehicle => {
-                if let Some(uri) = sink {
+            Self::OffVehicle => sink.map_or_else(
+                || {
+                    Err(UUriError::serialization_error(
+                        "Off-Vehicle transport requires sink URI for creating MQTT topic",
+                    ))
+                },
+                |uri| {
                     let mut topic = String::new();
                     topic.push_str(&Self::uri_to_authority_topic_segment(
                         source,
@@ -186,12 +191,8 @@ impl TransportMode {
                         fallback_authority,
                     ));
                     Ok(topic)
-                } else {
-                    Err(UUriError::serialization_error(
-                        "Off-Vehicle transport requires sink URI for creating MQTT topic",
-                    ))
-                }
-            }
+                },
+            ),
         }
     }
 }
@@ -332,7 +333,7 @@ impl Mqtt5Transport {
                     } else {
                         subscription_ids
                             .iter()
-                            .flat_map(|id| {
+                            .filter_map(|id| {
                                 registered_listeners_read
                                     .determine_listeners_for_subscription_id(*id)
                             })
@@ -377,10 +378,12 @@ impl Mqtt5Transport {
         let props = mapping::create_mqtt_properties_from_uattributes(attributes)?;
 
         // Get mqtt topic string from source and sink uuris
-        let src_uri = attributes.source.as_ref().ok_or(UStatus::fail_with_code(
-            UCode::INVALID_ARGUMENT,
-            "uProtocol Message has no source URI",
-        ))?;
+        let src_uri = attributes.source.as_ref().ok_or_else(|| {
+            UStatus::fail_with_code(
+                UCode::INVALID_ARGUMENT,
+                "uProtocol Message has no source URI",
+            )
+        })?;
         // [impl->dsn~up-transport-mqtt5-e2e-topic-names~1]
         // [impl->dsn~up-transport-mqtt5-d2d-topic-names~1]
         let topic = self
@@ -403,11 +406,11 @@ impl Mqtt5Transport {
         self.mqtt_client
             .publish(msg)
             .await
-            .inspect(|_| {
+            .inspect(|()| {
                 debug!(
                     "Successfully sent uProtocol message [MQTT topic: {}]",
                     topic
-                )
+                );
             })
             .inspect_err(|e| {
                 debug!("Failed to send uProtocol message [MQTT topic: {topic}]: {e}");
@@ -438,12 +441,11 @@ impl Mqtt5Transport {
                 // If subscribe fails, add subscription id back to free subscription ids.
                 registered_listeners_write.release_subscription_id(subscription_id, topic_filter);
                 return Err(sub_err);
-            } else {
-                debug!(
-                    "Created new subscription [topic filter: {}, id: {}] for listener",
-                    topic_filter, subscription_id
-                );
-            };
+            }
+            debug!(
+                "Created new subscription [topic filter: {}, id: {}] for listener",
+                topic_filter, subscription_id
+            );
         }
         Ok(())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-use std::sync::Arc;
+use std::{collections::HashSet, sync::Arc};
 
 use async_channel::Receiver;
 use bytes::Bytes;
@@ -330,8 +330,15 @@ impl Mqtt5Transport {
                     if subscription_ids.is_empty() {
                         registered_listeners_read.determine_listeners_for_topic(msg.topic())
                     } else {
-                        registered_listeners_read
-                            .determine_listeners_for_subscription_ids(subscription_ids.as_slice())
+                        subscription_ids
+                            .iter()
+                            .flat_map(|id| {
+                                registered_listeners_read
+                                    .determine_listeners_for_subscription_id(id)
+                            })
+                            .fold(HashSet::new(), |acc, elem| {
+                                acc.union(elem).cloned().collect()
+                            })
                     }
                 };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -334,7 +334,7 @@ impl Mqtt5Transport {
                             .iter()
                             .flat_map(|id| {
                                 registered_listeners_read
-                                    .determine_listeners_for_subscription_id(id)
+                                    .determine_listeners_for_subscription_id(*id)
                             })
                             .fold(HashSet::new(), |acc, elem| {
                                 acc.union(elem).cloned().collect()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -223,7 +223,6 @@ impl Mqtt5Transport {
     /// * `authority_name` - Authority name of the local uEntity.
     ///
     /// # Errors
-    /// 
     /// Will return an `Err` if the creation of the Paho client fails or if the incoming message
     /// stream is already taken.
     pub async fn new(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -221,6 +221,11 @@ impl Mqtt5Transport {
     /// # Arguments
     /// * `options` - Configuration options for the transport.
     /// * `authority_name` - Authority name of the local uEntity.
+    ///
+    /// # Errors
+    /// 
+    /// Will return an `Err` if the creation of the Paho client fails or if the incoming message
+    /// stream is already taken.
     pub async fn new(
         options: Mqtt5TransportOptions,
         authority_name: String,

--- a/src/listener_registry.rs
+++ b/src/listener_registry.rs
@@ -452,11 +452,9 @@ mod tests {
         let listeners =
             registered_listeners.determine_listeners_for_subscription_id(subscription_id);
         println!("{}", listeners.unwrap().len());
-        assert!(
-            listeners.is_some_and(|l| l.len() == 1
-                && !l.contains(&comparable_listener_1)
-                && l.contains(&comparable_listener_2))
-        );
+        assert!(listeners.is_some_and(|l| l.len() == 1
+            && !l.contains(&comparable_listener_1)
+            && l.contains(&comparable_listener_2)));
 
         assert!(registered_listeners.is_last_listener(topic_filter, listener_2.clone()));
         assert!(registered_listeners.remove_listener(topic_filter, listener_2.clone()));

--- a/src/listener_registry.rs
+++ b/src/listener_registry.rs
@@ -453,9 +453,9 @@ mod tests {
             registered_listeners.determine_listeners_for_subscription_id(subscription_id);
         println!("{}", listeners.unwrap().len());
         assert!(
-            listeners.unwrap().len() == 1
-                && !listeners.unwrap().contains(&comparable_listener_1)
-                && listeners.unwrap().contains(&comparable_listener_2)
+            listeners.is_some_and(|l| l.len() == 1
+                && !l.contains(&comparable_listener_1)
+                && l.contains(&comparable_listener_2))
         );
 
         assert!(registered_listeners.is_last_listener(topic_filter, listener_2.clone()));

--- a/src/listener_registry.rs
+++ b/src/listener_registry.rs
@@ -69,6 +69,8 @@ impl RegisteredListeners {
     fn find_subscription_id(&self, topic_filter: &str) -> Option<SubscriptionIdentifier> {
         self.subscription_topics.iter().find_map(|(idx, v)| {
             if v.0 == topic_filter {
+                // cannot fail because the slab has been initialized
+                // with a capacity <= u16::MAX
                 Some(u16::try_from(idx).expect(NO_VALID_U16))
             } else {
                 None

--- a/src/listener_registry.rs
+++ b/src/listener_registry.rs
@@ -222,13 +222,7 @@ impl RegisteredListeners {
         if !registered_listeners.remove(&ComparableListener::new(listener.clone())) {
             return false;
         }
-
-        if registered_listeners.is_empty() {
-            // find subscription ID for topic filter and release the subscription ID
-            if let Some(sub_id) = self.find_subscription_id(topic_filter) {
-                self.release_subscription_id(sub_id, topic_filter);
-            }
-        }
+        let now_empty = registered_listeners.is_empty();
 
         // Remove from subscription_id mapping
         if let Some(sub_id) = self.find_subscription_id(topic_filter) {
@@ -237,6 +231,10 @@ impl RegisteredListeners {
                 .unwrap()
                 .1
                 .remove(&ComparableListener::new(listener));
+            if now_empty {
+                // find subscription ID for topic filter and release the subscription ID
+                self.release_subscription_id(sub_id, topic_filter);
+            }
         }
         true
     }

--- a/src/listener_registry.rs
+++ b/src/listener_registry.rs
@@ -42,7 +42,7 @@ impl Default for RegisteredListeners {
 impl RegisteredListeners {
     pub(crate) fn new(max_subscriptions: u16, max_listeners_per_subscription: u16) -> Self {
         let mut sub_topics = SubscriptionTopics::with_capacity((max_subscriptions + 1).into());
-        sub_topics.insert(("".to_owned(), HashSet::new()));
+        sub_topics.insert((String::new(), HashSet::new()));
 
         Self {
             // MQTT subscription identifiers start with 1 so we add a dummy value
@@ -229,9 +229,9 @@ impl RegisteredListeners {
         self.topic_listeners
             .matches(topic)
             .for_each(|(_topic_filter, listeners)| {
-                listeners.iter().for_each(|listener| {
+                for listener in listeners {
                     listeners_to_invoke.insert(listener.to_owned());
-                });
+                }
             });
         listeners_to_invoke
     }
@@ -258,7 +258,7 @@ impl SubscribedTopicProvider for RegisteredListeners {
             .map(|(subscription_id, topic_filter)| {
                 (
                     u16::try_from(subscription_id).unwrap(),
-                    topic_filter.0.to_owned(),
+                    topic_filter.0.clone(),
                 )
             })
             .collect()

--- a/src/listener_registry.rs
+++ b/src/listener_registry.rs
@@ -55,7 +55,7 @@ impl RegisteredListeners {
         Self {
             subscription_topics: sub_topics,
             topic_listeners: TopicListeners::new(),
-            max_listeners_per_subscription: max_listeners_per_subscription as usize,
+            max_listeners_per_subscription: max_listeners_per_subscription.into(),
         }
     }
 

--- a/src/mapping.rs
+++ b/src/mapping.rs
@@ -22,7 +22,7 @@ use up_rust::{
 
 const CURRENT_UPROTOCOL_MAJOR_VERSION: u8 = 1;
 
-/// Constants defining the protobuf field numbers for UAttributes.
+/// Constants defining the protobuf field numbers for `UAttributes`.
 const KEY_UPROTOCOL_VERSION: &str = "uP";
 const KEY_MESSAGE_ID: &str = "1";
 const KEY_TYPE: &str = "2";
@@ -161,8 +161,8 @@ pub(crate) fn create_mqtt_properties_from_uattributes(
             KEY_SINK,
             &sink.to_uri(false),
             "Failed to add message sink to MQTT User Properties",
-        )?
-    };
+        )?;
+    }
 
     let prio = attributes.priority.enum_value().map_err(|v| {
         UStatus::fail_with_code(
@@ -176,7 +176,7 @@ pub(crate) fn create_mqtt_properties_from_uattributes(
             KEY_PRIORITY,
             &prio.to_priority_code(),
             "Failed to add message priority to MQTT User Properties",
-        )?
+        )?;
     }
 
     if let Some(permission_level) = &attributes.permission_level {
@@ -208,7 +208,7 @@ pub(crate) fn create_mqtt_properties_from_uattributes(
                     UCode::INTERNAL,
                     format!("Failed to create Correlation Data property: {e:?}"),
                 )
-            })?
+            })?;
     }
 
     if let Some(token) = &attributes.token {
@@ -258,7 +258,7 @@ pub(crate) fn create_uattributes_from_mqtt_properties(
     props: &paho_mqtt::Properties,
 ) -> Result<UAttributes, UStatus> {
     let uprotocol_major_version = props.find_user_property(KEY_UPROTOCOL_VERSION)
-        .ok_or(UStatus::fail_with_code(UCode::INVALID_ARGUMENT, "MQTT message does not contain uProtocol version identifier"))
+        .ok_or_else(||UStatus::fail_with_code(UCode::INVALID_ARGUMENT, "MQTT message does not contain uProtocol version identifier"))
         .and_then(|s| s.parse::<u8>().map_err(|err| UStatus::fail_with_code(UCode::INVALID_ARGUMENT, format!("Failed to map UserProperty {KEY_UPROTOCOL_VERSION} to uProtocol major version: {err}"))))?;
     if uprotocol_major_version != CURRENT_UPROTOCOL_MAJOR_VERSION {
         return Err(UStatus::fail_with_code(UCode::INVALID_ARGUMENT, format!("MQTT message contains unsupported uProtocol major version [expected: {CURRENT_UPROTOCOL_MAJOR_VERSION}, found: {uprotocol_major_version}")));
@@ -278,7 +278,7 @@ pub(crate) fn create_uattributes_from_mqtt_properties(
             )
         })?;
         attributes.id = MessageField::from(Some(id));
-    };
+    }
 
     if let Some(message_type_str) = props.find_user_property(KEY_TYPE) {
         attributes.type_ = UMessageType::try_from_cloudevent_type(message_type_str)
@@ -300,7 +300,7 @@ pub(crate) fn create_uattributes_from_mqtt_properties(
                 )
             })
             .map(MessageField::some)?;
-    };
+    }
 
     if let Some(sink_string) = props.find_user_property(KEY_SINK) {
         attributes.sink = UUri::from_str(&sink_string)
@@ -311,7 +311,7 @@ pub(crate) fn create_uattributes_from_mqtt_properties(
                 )
             })
             .map(MessageField::some)?;
-    };
+    }
 
     if let Some(priority_string) = props.find_user_property(KEY_PRIORITY) {
         attributes.priority = UPriority::try_from_priority_code(priority_string)
@@ -357,7 +357,7 @@ pub(crate) fn create_uattributes_from_mqtt_properties(
                 )
             })
             .map(Option::Some)?;
-    };
+    }
 
     if let Some(comm_status_string) = props.find_user_property(KEY_COMMSTATUS) {
         attributes.commstatus = comm_status_string
@@ -369,7 +369,7 @@ pub(crate) fn create_uattributes_from_mqtt_properties(
                 )
             })
             .and_then(|v| {
-                UCode::from_i32(v).ok_or({
+                UCode::from_i32(v).ok_or_else(||{
                     UStatus::fail_with_code(
                         UCode::INVALID_ARGUMENT,
                         format!("Failed to map UserProperty {KEY_COMMSTATUS} to CommStatus: not a valid UCode [{v}]"),
@@ -383,7 +383,7 @@ pub(crate) fn create_uattributes_from_mqtt_properties(
     if let Some(req_id) = props.get_binary(paho_mqtt::PropertyCode::CorrelationData) {
         let uuid = uuid_from_bytes(req_id)?;
         attributes.reqid = Some(uuid).into();
-    };
+    }
 
     if let Some(payload_format_string) = props.get_string(paho_mqtt::PropertyCode::ContentType) {
         attributes.payload_format = payload_format_string
@@ -392,7 +392,7 @@ pub(crate) fn create_uattributes_from_mqtt_properties(
               UCode::INVALID_ARGUMENT,
               format!("Failed to map Content Type to Message Payload Format: {err}")))
             .and_then(|v| {
-                UPayloadFormat::from_i32(v).ok_or(UStatus::fail_with_code(
+                UPayloadFormat::from_i32(v).ok_or_else(||UStatus::fail_with_code(
                     UCode::INVALID_ARGUMENT,
                     format!("Failed to map Content Type to Message Payload Format: not a valid payload format code [{v}]"),
                 ))

--- a/src/mqtt_client.rs
+++ b/src/mqtt_client.rs
@@ -288,7 +288,7 @@ pub(crate) struct PahoBasedMqttClientOperations {
 }
 
 impl PahoBasedMqttClientOperations {
-    fn ustatus_from_paho_error(paho_error: paho_mqtt::Error) -> UStatus {
+    fn ustatus_from_paho_error(paho_error: &paho_mqtt::Error) -> UStatus {
         match paho_error {
             paho_mqtt::Error::Disconnected => {
                 UStatus::fail_with_code(UCode::UNAVAILABLE, "not connected to MQTT broker")
@@ -319,7 +319,7 @@ impl PahoBasedMqttClientOperations {
         paho_mqtt::CreateOptionsBuilder::new()
             .server_uri(&options.broker_uri)
             .client_id(options.client_id.clone().unwrap_or_default())
-            .max_buffered_messages(options.max_buffered_messages as i32)
+            .max_buffered_messages(i32::from(options.max_buffered_messages))
             .user_data(Box::new(RwLock::new(ConnectionState::default())))
             .create_client()
             .map_err(|e| {
@@ -383,7 +383,7 @@ impl PahoBasedMqttClientOperations {
 
     /// Updates the MQTT client's [user data](`ConnectionState`) with the connection properties
     /// contained in the CONNACK packet returned by the MQTT broker.
-    fn handle_connect_response(user_data: &paho_mqtt::UserData, token: paho_mqtt::ServerResponse) {
+    fn handle_connect_response(user_data: &paho_mqtt::UserData, token: &paho_mqtt::ServerResponse) {
         if let Some(connection_properties) = user_data.downcast_ref::<RwLock<ConnectionState>>() {
             if let Ok(mut props) = connection_properties.write() {
                 props.subscription_ids_supported = token
@@ -409,9 +409,12 @@ impl PahoBasedMqttClientOperations {
     ) -> Result<paho_mqtt::Properties, paho_mqtt::Error> {
         let mut properties = paho_mqtt::Properties::new();
         properties
-            .push_int(paho_mqtt::PropertyCode::SubscriptionIdentifier, id as i32)
+            .push_int(
+                paho_mqtt::PropertyCode::SubscriptionIdentifier,
+                i32::from(id),
+            )
             .inspect_err(|e| {
-                debug!("Failed to create MQTT 5 SubscriptionIdentifier property: {e}")
+                debug!("Failed to create MQTT 5 SubscriptionIdentifier property: {e}");
             })?;
         Ok(properties)
     }
@@ -435,12 +438,11 @@ impl PahoBasedMqttClientOperations {
                     subscription_id, topic_filter, err,
                 );
                 return Err(err);
-            } else {
-                debug!(
-                    "Successfully recreated subscription [id: {}, topic filter: {}]",
-                    subscription_id, topic_filter
-                );
             }
+            debug!(
+                "Successfully recreated subscription [id: {}, topic filter: {}]",
+                subscription_id, topic_filter
+            );
         }
         Ok(())
     }
@@ -460,7 +462,7 @@ impl MqttClientOperations for PahoBasedMqttClientOperations {
             .await
             .map(|response| {
                 if let Some(user_data) = self.inner_mqtt_client.user_data() {
-                    Self::handle_connect_response(user_data, response);
+                    Self::handle_connect_response(user_data, &response);
                 }
             })
             .map_err(|e| {
@@ -507,7 +509,7 @@ impl MqttClientOperations for PahoBasedMqttClientOperations {
                 if let Some(user_data) = mqtt_client.user_data() {
                     // this will always be the case because we set the user data during
                     // construction of the AsyncClient
-                    Self::handle_connect_response(user_data, response);
+                    Self::handle_connect_response(user_data, &response);
                     if !Self::is_session_present(user_data) {
                         // we only need to manually reestablish the subscriptions if
                         // the server has not used any session state for the new connection
@@ -571,8 +573,7 @@ impl MqttClientOperations for PahoBasedMqttClientOperations {
         self.inner_mqtt_client
             .publish(mqtt_message)
             .await
-            .map_err(Self::ustatus_from_paho_error)
-            .map(|_| ())
+            .map_err(|paho_error| Self::ustatus_from_paho_error(&paho_error))
     }
 
     async fn subscribe(&self, topic: &str, id: u16) -> Result<(), UStatus> {
@@ -601,7 +602,7 @@ impl MqttClientOperations for PahoBasedMqttClientOperations {
             // QOS 1 - Delivered and received at least once
             .subscribe_with_options(topic, paho_mqtt::QOS_1, None, subscription_properties)
             .await
-            .map_err(Self::ustatus_from_paho_error)
+            .map_err(|paho_error| Self::ustatus_from_paho_error(&paho_error))
             .map(|_| ())
     }
 
@@ -609,7 +610,7 @@ impl MqttClientOperations for PahoBasedMqttClientOperations {
         self.inner_mqtt_client
             .unsubscribe(topic)
             .await
-            .map_err(Self::ustatus_from_paho_error)
+            .map_err(|paho_error| Self::ustatus_from_paho_error(&paho_error))
             .map(|_| ())
     }
 }

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -62,10 +62,12 @@ impl UTransport for Mqtt5Transport {
     async fn send(&self, message: UMessage) -> Result<(), UStatus> {
         // validate message
         // [impl->dsn~utransport-send-error-invalid-parameter~1]
-        let attributes = message.attributes.as_ref().ok_or(UStatus::fail_with_code(
-            UCode::INVALID_ARGUMENT,
-            "uProtocol message has no attributes",
-        ))?;
+        let attributes = message.attributes.as_ref().ok_or_else(|| {
+            UStatus::fail_with_code(
+                UCode::INVALID_ARGUMENT,
+                "uProtocol message has no attributes",
+            )
+        })?;
 
         // Extract payload from umessage to send
         // [impl->dsn~up-transport-mqtt5-payload-mapping~1]


### PR DESCRIPTION
This fixes: https://github.com/eclipse-uprotocol/up-transport-mqtt5-rust/issues/46

Idea is to store a map sub_id -> (topic, listener) to avoid the costly topic_matcher regex lookup. This patch also removes the hashmap to store this mapping but uses slab instead. Some clippy lints from 

cargo clippy -- -Wclippy::nursery -Wclippy::pedantic

were also fixed where it made sense. 