### PR TITLE
Add tests for authorization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,9 +102,9 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "astral-tokio-tar"
-version = "0.5.6"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec179a06c1769b1e42e1e2cbe74c7dcdb3d6383c838454d063eaac5bbb7ebbe5"
+checksum = "3c23f3af104b40a3430ccb90ed5f7bd877a8dc5c26fc92fde51a22b40890dcf9"
 dependencies = [
  "filetime",
  "futures-core",
@@ -118,13 +118,14 @@ dependencies = [
 
 [[package]]
 name = "async-channel"
-version = "1.9.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
 dependencies = [
  "concurrent-queue",
- "event-listener",
+ "event-listener-strategy",
  "futures-core",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -587,9 +588,24 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "2.5.3"
+version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "fastrand"
@@ -1483,9 +1499,9 @@ checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "paho-mqtt"
-version = "0.13.3"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2a9dc54c16b2e290ab3045b214a2a4effb61a42cf920cc83aa250367a4cceed"
+checksum = "23c6e899549be260b8c8d7fb6908d72eacb9a1e10229c7e294a7a8ff1c768620"
 dependencies = [
  "async-channel",
  "crossbeam-channel",
@@ -1494,18 +1510,24 @@ dependencies = [
  "libc",
  "log",
  "paho-mqtt-sys",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "paho-mqtt-sys"
-version = "0.10.3"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d3094e35ab92c9ffa90775d8faad0e8ecac0a0ed4c409c3e683cbf84f784287"
+checksum = "00e508bdadfa0d58d67792060fa447ec20729db5dc76e3dc7de9f4d29e521a43"
 dependencies = [
  "cmake",
  "openssl-sys",
 ]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -2425,9 +2447,9 @@ dependencies = [
 
 [[package]]
 name = "testcontainers"
-version = "0.27.1"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1c0624faaa317c56d6d19136580be889677259caf5c897941c6f446b4655068"
+checksum = "0bd36b06a2a6c0c3c81a83be1ab05fe86460d054d4d51bf513bc56b3e15bdc22"
 dependencies = [
  "astral-tokio-tar",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ default = ["cli"]
 cli = ["clap"]
 
 [dependencies]
-async-channel = { version = "1.9" }
+async-channel = { version = "2.0.0" }
 async-trait = { version = "0.1" }
 backon = { version = "1.6", default-features = false, features = ["tokio-sleep"] }
 bytes = { version = "1.11.1" }
@@ -45,14 +45,14 @@ clap = { version = "4.5", optional = true, default-features = false, features = 
 ] }
 futures = { version = "0.3" }
 log = { version = "0.4" }
-paho-mqtt = { version = "0.13.3", features = ["vendored-ssl"] }
+paho-mqtt = { version = "0.14.0", features = ["vendored-ssl"] }
 protobuf = { version = "3.7.2" }
 slab = { version = "0.4.11" }
 tokio = { version = "1.45.1", default-features = false, features = ["rt", "rt-multi-thread", "sync"] }
 up-rust = { version = "0.9", default-features = false }
 
 [build-dependencies]
-testcontainers = { version = "0.27.1", default-features = false, features = ["blocking"] }
+testcontainers = { version = "0.27.2", default-features = false, features = ["blocking"] }
 
 [dev-dependencies]
 env_logger = { version = "0.11.8" }
@@ -60,7 +60,7 @@ mockall = { version = "0.14.0" }
 serial_test = { version = "3.2.0" }
 tempfile = { version = "3.23.0" }
 test-case = { version = "3.3.1" }
-testcontainers = { version = "0.27.1", default-features = false }
+testcontainers = { version = "0.27.2", default-features = false }
 # https://rustsec.org/advisories/RUSTSEC-2026-0049
 rustls-webpki = { version = "0.103.10" }
 # https://rustsec.org/advisories/RUSTSEC-2026-0009

--- a/DESIGN.adoc
+++ b/DESIGN.adoc
@@ -1,0 +1,77 @@
+= Implementation Design
+:toc: preamble
+:sectnums:
+
+----
+SPDX-FileCopyrightText: 2024 Contributors to the Eclipse Foundation
+
+See the NOTICE file(s) distributed with this work for additional
+information regarding copyright ownership.
+
+This program and the accompanying materials are made available under
+the terms of the Apache License Version 2.0 which is available at
+https://www.apache.org/licenses/LICENSE-2.0
+ 
+SPDX-FileType: DOCUMENTATION
+SPDX-License-Identifier: Apache-2.0
+----
+
+== Overview
+
+This document contains information regarding some design decisions made for the implementation of the transport.
+
+[.specitem,oft-sid="dsn~utransport-send-ignore-priority~1",oft-covers="req~utransport-send-qos-mapping~1"]
+== Message Priority Mapping
+
+The MQTT 5 standard does not define any mechanism for message prioritization. All messages are being processed with the same priority.
+Consequently, the MQTT 5 transport provided by this crate simply ignores the service class set on a uProtocol message being sent.
+
+[.specitem,oft-sid="dsn~utransport-supported-message-delivery~1",oft-covers="req~utransport-delivery-methods~1",oft-needs="impl,utest"]
+== Message Delivery
+
+All messages are being received by means of subscribing to relevant topics on the MQTT broker and delivering the messages to listeners that have been registered via `up_rust::UTransport::register_listener`.
+The transport spawns a dedicated [tokio task](https://tokio.rs/tokio/tutorial/spawning#tasks) that listens for incoming messages and dispatches them to the registered listeners on the same thread that the message handling task runs on.
+
+Rationale:
+The MQTT 5 standard does not provide means to poll the broker for messages but only supports the push model by means of clients subscribing to topic filters.
+
+The transport requires a tokio runtime to execute but does not make any implicit assumption regarding the availability and size of thread pools. This provides for flexibility regarding the environment that the transport can be deployed to but also requires application developers to take care when implementing message listeners, making sure to not block the transport's incoming message handler when processing a dispatched message.
+
+[.specitem,oft-sid="dsn~mqtt5-transport-authorization~1",oft-covers="req~utransport-registerlistener-prevent-unauthorized-access~1,req~utransport-send-prevent-address-spoofing~1",oft-needs="impl,utest"]
+## Authorization
+
+This crate provides an implementation of the uProtocol Transport Layer API. This API can be used by client code (uEntities) for sending and/or receiving messages to/from other uEntities. In general, this crate **does not** impose any restrictions on a message's source and sink addresses when handling messages. In particular, the crate itself **does not** verify a uEntity's _identity_ nor checks a uEntity's _authority_ to send and/or receive messages using particular addresses (UUris).
+
+However, the transport implementation provided by this crate supports the configuration of client credentials (username/password and/or X.509 certificate) for authenticating to an MQTT 5 broker during connection establishment.
+
+When a uEntity using this transport tries to connect to a broker using invalid credentials, the broker will return an MQTT _CONNACK_ packet including a corresponding _Reason Code_ back to the client (see section 3.2.2.2 of the MQTT 5 specification for details). This transport's function for connecting to the broker will fail with a `UStatus` error having a `UCode` as defined in <<Mapping of MQTT 5 Reason Codes to UCodes>>.
+
+Most MQTT brokers allow the configuration of _Access Control Lists_ (ACL), which can be used to restrict a client identity's access to certain MQTT topic patterns only. Given a set of ACLs for a uEntity using this transport implementation:
+
+1. When the uEntity tries to send a message using a source and/or sink address which map to an MQTT topic that the client is not authorized to publish to, the broker will return an MQTT _PUBACK_ packet including a corresponding failure _Reason Code_ to the client (see section 3.4.2.1 of the MQTT 5 specification for details).
+2. When a uEntity tries to subscribe to messages using a source and/or sink address pattern which results in an MQTT topic that the client is not authorized to subscribe to, the broker will return a corresponding _Reason Code_ in its MQTT _SUBACK_ packet sent back to the client (see section 3.9.3 of the MQTT 5 specification for details).
+
+The transport implementation will fail the invoked function with a `UStatus` error having a `UCode` as defined in <<Mapping of MQTT 5 Reason Codes to UCodes>>.
+
+[#reason-code-mapping]
+[.specitem,oft-sid="dsn~mapping-of-reason-codes~1",oft-needs="impl,utest"]
+## Mapping of MQTT 5 Reason Codes to UCodes
+
+This transport maps Reason Codes from MQTT 5 packets to uProtocol `UCode`s as follows
+
+[width="50%",cols="1,2"]
+|===
+| Reason Code | UCode
+
+|`0x86`|`UNAUTHENTICATED`
+|`0x87`|`PERMISSION_DENIED`
+|`0x88`|`UNAVAILABLE`
+|`0x89`|`UNAVAILABLE`
+|`0x8C`|`UNAUTHENTICATED`
+|`0x96`|`RESOURCE_EXHAUSTED`
+|`0x97`|`RESOURCE_EXHAUSTED`
+|`0x9F`|`RESOURCE_EXHAUSTED`
+|`0xA0`|`RESOURCE_EXHAUSTED`
+|===
+
+All other (error) reason codes > 0x80 are mapped to `INTERNAL`.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,18 @@ This library provides a Rust based implementation of the [MQTT 5 uProtocol Trans
 
 ## Getting Started
 
+Add the following to the `[dependencies]` section of your `Cargo.toml` file:
+
+```toml
+[dependencies]
+up-rust = { version = "0.9" }
+up-transport-mqtt5 = { version = "0.4" }
+```
+
+Please refer to [the crate's Rust Docs](https://docs.rs/up-transport-mqtt5/) and the [examples](./examples/) folder to see how to configure and use the transport.
+
+## Building from Source
+
 ### Clone the Repository
 
 ```sh
@@ -34,116 +46,36 @@ cargo test
 
 ### Running the Examples
 
-The example shows how the transport can be used to publish uProtocol messages from one uEntity and consume these messages on another uEntity.
+The examples show how the transport can be used to publish uProtocol messages from one uEntity and consume these messages on another uEntity.
 
 1. Start the Eclipse Mosquitto MQTT broker using Docker Compose:
 
-```bash
-docker compose -f tests/mosquitto/docker-compose.yaml up --detach
-```
+   ```bash
+   docker compose -f tests/mosquitto/docker-compose.yaml up --detach
+   ```
 
-2. Run the Subscriber
+2. Run the Subscriber with options appropriate for your MQTT broker.
+   When using the Mosquitto broker started via Docker Compose, then the defaults should work:
 
-The Subscriber supports configuration via command line options and/or environment variables:
+   ```bash
+   cargo run --example subscriber_example
+   ```
 
-```bash
-cargo run --example subscriber_example -- --help
-```
+   The Subscriber also supports configuration via command line options and/or environment variables:
 
-Run the Subscriber with options appropriate for your MQTT broker. When using the Mosquitto broker started via Docker Compose, then the defaults should work:
+   ```bash
+   cargo run --example subscriber_example -- --help
+   ```
 
-```bash
-cargo run --example subscriber_example
-```
+3. Run the Publisher with options appropriate for your MQTT broker.
+   When using the Mosquitto broker started via Docker Compose, then the defaults should work:
 
-3. Run the Publisher
+   ```bash
+   cargo run --example publisher_example
+   ```
 
-The Publisher supports configuration via command line options and/or environment variables:
+   The Publisher also supports configuration via command line options and/or environment variables:
 
-```bash
-cargo run --example publisher_example -- --help
-```
-
-Run the Publisher with options appropriate for your MQTT broker. When using the Mosquitto broker started via Docker Compose, then the defaults should work:
-
-```bash
-cargo run --example publisher_example
-```
-
-## Using the Library
-
-Most developers will want to create an instance of the *Mqtt5Transport* struct and use it with the Communication Level API and its default implementation
-which are provided by the *up-rust* library.
-
-The libraries need to be added to the `[dependencies]` section of the `Cargo.toml` file:
-
-```toml
-[dependencies]
-up-rust = { version = "0.9" }
-up-transport-mqtt5 = { version = "0.4" }
-```
-
-Please refer to the [publisher_example](./examples/publisher_example.rs) and [subscriber_example](./examples/subscriber_example.rs) to see how to initialize and use the transport.
-
-The library contains the following modules:
-
-| Module    | uProtocol Specification                                                                                 | Purpose                                                                                                   |
-| --------- | ------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
-| transport | [uP-L1 Specifications](https://github.com/eclipse-uprotocol/up-spec/blob/v1.6.0-alpha.7/up-l1/README.adoc) | Implementation of MQTT5 uTransport client used for bidirectional point-2-point communication between uEs. |
-
-### Supported Message Priority Levels
-`uman~utransport-send-ignore-priority~1`
-
-The `Mqtt5Transport::send` function always uses a standard MQTT 5 PUBLISH packet to transfer the message to the MQTT broker regardless of the service class set on a uProtocol message.
-
-Covers:
-- req~utransport-send-qos-mapping~1
-
-### Supported Message Delivery Methods
-`uman~utransport-supported-message-delivery~1`
-
-The MQTT 5 transport provided by this crate supports the [push delivery method](https://github.com/eclipse-uprotocol/up-spec/blob/v1.6.0-alpha.7/up-l1/README.adoc#5-message-delivery) only.
-The `Mqtt5Transport::receive` function therefore always returns `UCode::UNIMPLEMENTED`.
-
-Covers:
-- `req~utransport-delivery-methods~1`
-
-### Maximum number of listeners
-`uman~max-listeners-configuration~1`
-
-The MQTT 5 transport provided by this crate can be configured with the maximum number of filter patterns that listeners can be registered for by means of the `MqttTransportOptions` struct that is being passed into `Mqtt5Transport::new`.
-Please refer to the [API Documentation](https://docs.rs/up-transport-mqtt5/) for details.
-
-Covers:
-- `req~utransport-registerlistener-max-listeners~1`
-
-### Known Limitations
-
-The crate currently does not use the proper UCode to indicate authorization problems when sending messages or registering listeners.
-
-## Design
-
-### Message Priority Mapping
-`dsn~utransport-send-ignore-priority~1`
-
-The MQTT 5 standard does not define any mechanism for message prioritization. All messages are being processed with the same priority.
-Consequently, the MQTT 5 transport provided by this crate simply ignores the service class set on a uProtocol message being sent.
-
-Covers:
-- `req~utransport-send-qos-mapping~1`
-
-### Message Delivery
-`dsn~utransport-supported-message-delivery~1`
-
-All messages are being received by means of subscribing to relevant topics on the MQTT broker and delivering the messages to listeners that have been registered via `up_rust::UTransport::register_listener`.
-The transport spawns a dedicated [tokio task](https://tokio.rs/tokio/tutorial/spawning#tasks) that listens for incoming messages and dispatches them to the registered listeners on the same thread that the message handling task runs on.
-
-Rationale:
-The MQTT 5 standard does not provide means to poll the broker for messages but only supports the push model by means of clients subscribing to topic filters.
-
-The transport requires a tokio runtime to execute but does not make any implicit assumption regarding the availability and size of thread pools. This provides for flexibility regarding the environment that the transport can be deployed to but also requires application developers to take care when implementing message listeners, making sure to not block the transport's incoming message handler when processing a dispatched message.
-
-Covers:
-- `req~utransport-delivery-methods~1`
-
-Needs: impl, utest
+   ```bash
+   cargo run --example publisher_example -- --help
+   ```

--- a/about.toml
+++ b/about.toml
@@ -6,7 +6,6 @@ accepted = [
     "Apache-2.0",
     "BSD-2-Clause",
     "BSD-3-Clause",
-    "CDLA-Permissive-2.0",
     "EPL-2.0",
     "ISC",
     "MIT",

--- a/deny.toml
+++ b/deny.toml
@@ -19,7 +19,6 @@ allow = [
     "Apache-2.0",
     "BSD-2-Clause",
     "BSD-3-Clause",
-    "CDLA-Permissive-2.0",
     "EPL-2.0",
     "ISC",
     "MIT",
@@ -39,6 +38,4 @@ skip-tree = [
 
 [advisories]
 ignore = [
-    # https://rustsec.org/advisories/RUSTSEC-2026-0066
-    { id = "RUSTSEC-2026-0066", reason = "this affects the testcontainers crate which is used for running tests only" },
 ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,6 @@ use async_channel::Receiver;
 use bytes::Bytes;
 #[cfg(feature = "cli")]
 use clap::{Args, ValueEnum};
-use futures::stream::StreamExt;
 use listener_registry::{RegisteredListeners, SubscriptionIdentifier};
 use log::{debug, trace};
 use mqtt_client::MqttClientOperations;
@@ -429,12 +428,12 @@ impl Mqtt5Transport {
     /// * `registered_listeners` - Map of topic filters to listeners.
     /// * `message_stream` - Stream of incoming MQTT PUBLISH packets.
     /// * `mqtt_client_operations` - The client to use for interacting with the MQTT broker.
-    fn create_cb_message_handler(&mut self, mut message_stream: Receiver<Option<Message>>) {
+    fn create_cb_message_handler(&mut self, message_stream: Receiver<Option<Message>>) {
         let cloned_client_operations = self.mqtt_client.clone();
         let cloned_registered_listeners = self.registered_listeners.clone();
         let cloned_message_mapper = self.message_mapper.clone();
         let handle = tokio::spawn(async move {
-            while let Some(msg_opt) = message_stream.next().await {
+            while let Ok(msg_opt) = message_stream.recv().await {
                 let Some(msg) = msg_opt else {
                     // None means that the connection is dropped.
                     debug!("Lost connection to MQTT broker");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@
  ********************************************************************************/
 
 /*!
-This crate provides an implementation of the MQTT 5 uProtocol Transport.
+This crate provides an implementation of the [uProtocol MQTT 5 Transport v1.6.0-alpha.7](https://github.com/eclipse-uprotocol/up-spec/blob/v1.6.0-alpha.7/up-l1/mqtt_5.adoc).
 
 The transport requires an MQTT 5 broker to connect to and uses MQTT 5 `PUBLISH`
 packets to transfer uProtocol messages between uEntities.
@@ -27,8 +27,23 @@ processing requirements of the use case at hand. The transport does
 not make any implicit assumptions about the number of threads available
 and does not spawn any threads itself.
 
+## Using the Library
+
+Most developers will want to create an instance of the [Mqtt5Transport] struct and use it with uProtocol's Communication Layer API and its default implementation which are provided by the *up-rust* library. The crate also provides an implementation of [uProtocol's Transport & Session Layer API](up_rust::UTransport) which can be used to send and receive arbitrary (uProtocol) messages regardless of any message exchange patterns as imposed by the Communication Layer API.
+
+The libraries need to be added to the `[dependencies]` section of the `Cargo.toml` file:
+
+```toml
+[dependencies]
+up-rust = { version = "0.9" }
+up-transport-mqtt5 = { version = "0.4" }
+```
+
+Please refer to the [examples](https://github.com/eclipse-uprotocol/up-transport-mqtt5-rust/tree/v0.4.0/examples) folder to see how to initialize and use the transport.
+
 [tokio `Runtime`]: https://docs.rs/tokio/latest/tokio/runtime/index.html
 */
+
 use std::collections::HashSet;
 use std::sync::Arc;
 
@@ -42,6 +57,8 @@ use mqtt_client::MqttClientOperations;
 pub use mqtt_client::{MqttClientOptions, SslOptions};
 use paho_mqtt::{self as mqtt, Message, QOS_1};
 use tokio::{sync::RwLock, task::JoinHandle};
+#[allow(unused_imports)]
+use up_rust::UTransport;
 use up_rust::{ComparableListener, UAttributes, UCode, UMessage, UStatus, UUri, UUriError};
 
 mod listener_registry;
@@ -311,17 +328,50 @@ fn verify_authority_name<S: Into<String>>(authority: S) -> Result<String, UStatu
 ///
 /// The transport spawns a dedicated tokio task that listens for incoming messages
 /// and dispatches them to the listeners that have been registered using
-/// `up_rust::UTransport::register_listener`.
+/// [up_rust::UTransport::register_listener].
 ///
 /// <div class="warning">
 ///
 /// The registered listeners are being invoked sequentially on the **same thread**
 /// that the message handling task runs on. Implementers of listeners are therefore
 /// **strongly advised** to move non-trivial processing logic to **another/dedicated
-/// thread**, if necessary. Please refer to the `subscriber_example` in the
-/// examples directory for how this could be done.
+/// thread**, if necessary. Please refer to the *subscriber_example* in the
+/// *examples* folder for how this could be done.
 ///
 /// </div>
+///
+/// ### Supported Message Priority Levels
+///
+/// The [Self::send] function always uses a standard MQTT 5 PUBLISH packet to transfer the message
+/// to the MQTT broker regardless of the service class (priority) set on a uProtocol message.
+///
+/// ### Supported Message Delivery Methods
+///
+/// The transport supports the [push delivery method](https://github.com/eclipse-uprotocol/up-spec/blob/v1.6.0-alpha.7/up-l1/README.adoc#5-message-delivery) only.
+/// The [Self::receive] function therefore always returns [UCode::UNIMPLEMENTED].
+///
+/// ### Maximum number of listeners
+///
+/// The transport can be configured with the maximum number of filter patterns that listeners can
+/// be registered for by means of the [Mqtt5TransportOptions] struct that is being passed into [Self::new].
+///
+/// ### Authentication & Authorization
+///
+/// The transport can be configured with credentials that the transport will provide to the MQTT 5
+/// broker during connection establishment. A _username_ and _password_ and/or an X.509 client certificate
+/// can be specified as part of the [Mqtt5TransportOptions] that are passed into the [Self::new] function
+/// for creating a transport instance.
+///
+/// The mechanism for configuring access to topics is specific to the particular MQTT 5 broker at hand.
+/// The code in the [integration tests folder](https://github.com/eclipse-uprotocol/up-transport-mqtt5-rust/tree/v0.4.0/tests)
+/// illustrates, how ACLs can be used with an Eclipse Mosquitto MQTT broker to restrict a client's
+/// authority to publish messages and subscribe to topics.
+///
+// [uman->req~utransport-send-qos-mapping~1]
+// [uman->req~utransport-delivery-methods~1]
+// [uman->req~utransport-registerlistener-max-listeners~1]
+// [uman->req~utransport-send-prevent-address-spoofing~1]
+// [uman->req~utransport-registerlistener-prevent-unauthorized-access~1]
 pub struct Mqtt5Transport {
     /// Client instance for connecting to mqtt broker.
     mqtt_client: Arc<dyn MqttClientOperations>,
@@ -339,16 +389,20 @@ impl Mqtt5Transport {
     /// Creates a new transport.
     ///
     /// The connection to the MQTT broker needs to be established by means of the
-    /// [`Self::connect`] function. This allows for clients to implement any particular
+    /// [Self::connect] function. This allows for clients to implement any particular
     /// connection strategy using e.g. an exponential backoff for subsequent connection
     /// attempts.
     ///
     /// # Arguments
     /// * `options` - Configuration options for the transport.
-    /// * `authority_name` - Authority name of the local uEntity.
+    /// * `authority_name` - The (logical) name to use for the host that the local uEntity runs on.
+    ///   This name will be used as part of the origin and destination addresses of uProtocol messages.
+    ///   It is important to use a meaningful authority name here and make sure that it is unique across all
+    ///   uEntities in the same deployment, otherwise message filtering will not work correctly.
     ///
     /// # Errors
-    /// Will return an error if the creation of the Paho client fails, or if the given authority name is invalid.
+    /// Will return an error if the creation of the underlying Paho MQTT client fails, or if the given authority
+    /// name is invalid.
     pub async fn new<S: Into<String>>(
         options: Mqtt5TransportOptions,
         authority_name: S,

--- a/src/mqtt_client.rs
+++ b/src/mqtt_client.rs
@@ -23,7 +23,7 @@ use async_trait::async_trait;
 use backon::Retryable;
 #[cfg(feature = "cli")]
 use clap::Args;
-use log::{debug, trace};
+use log::{debug, error, trace};
 use up_rust::{UCode, UStatus};
 
 use crate::{listener_registry::SubscribedTopicProvider, SubscriptionIdentifier};
@@ -150,7 +150,7 @@ impl TryFrom<&MqttClientOptions> for paho_mqtt::ConnectOptions {
             connect_options_builder.user_name(v);
         }
         if let Some(v) = options.password.as_ref() {
-            connect_options_builder.password(v);
+            connect_options_builder.password(v.as_bytes());
         }
         Ok(connect_options_builder.finalize())
     }
@@ -218,6 +218,49 @@ impl TryFrom<&SslOptions> for paho_mqtt::SslOptions {
             builder.private_key_password(pwd);
         }
         Ok(builder.finalize())
+    }
+}
+
+fn ustatus_from_paho_error(paho_error: paho_mqtt::Error) -> UStatus {
+    match paho_error {
+        paho_mqtt::Error::Disconnected => {
+            UStatus::fail_with_code(UCode::UNAVAILABLE, "not connected to MQTT broker")
+        }
+        paho_mqtt::Error::TcpTlsConnectFailure => {
+            UStatus::fail_with_code(UCode::UNAVAILABLE, "failed to connect to MQTT broker")
+        }
+        paho_mqtt::Error::ReasonCode(paho_mqtt::ReasonCode::BadUserNameOrPassword, _) => {
+            UStatus::fail_with_code(UCode::UNAUTHENTICATED, "bad credentials")
+        }
+        // [impl->dsn~mqtt5-transport-authorization~1]
+        paho_mqtt::Error::ReasonCode(paho_mqtt::ReasonCode::NotAuthorized, _) => {
+            UStatus::fail_with_code(UCode::PERMISSION_DENIED, "not authorized")
+        }
+        paho_mqtt::Error::ReasonCode(paho_mqtt::ReasonCode::ServerUnavailable, _) => {
+            UStatus::fail_with_code(UCode::UNAVAILABLE, "server not available")
+        }
+        paho_mqtt::Error::ReasonCode(paho_mqtt::ReasonCode::ServerBusy, _) => {
+            UStatus::fail_with_code(UCode::UNAVAILABLE, "server busy")
+        }
+        paho_mqtt::Error::ReasonCode(paho_mqtt::ReasonCode::BadAuthenticationMethod, _) => {
+            UStatus::fail_with_code(UCode::UNAUTHENTICATED, "bad authentication method")
+        }
+        paho_mqtt::Error::ReasonCode(paho_mqtt::ReasonCode::MessageRateTooHigh, _) => {
+            UStatus::fail_with_code(UCode::RESOURCE_EXHAUSTED, "message rate to high")
+        }
+        paho_mqtt::Error::ReasonCode(paho_mqtt::ReasonCode::QuotaExceeded, _) => {
+            UStatus::fail_with_code(UCode::RESOURCE_EXHAUSTED, "quota exceeded")
+        }
+        paho_mqtt::Error::ReasonCode(paho_mqtt::ReasonCode::ConnectionRateExceeded, _) => {
+            UStatus::fail_with_code(UCode::RESOURCE_EXHAUSTED, "connection rate exceeded")
+        }
+        paho_mqtt::Error::ReasonCode(paho_mqtt::ReasonCode::MaximumConnectTime, _) => {
+            UStatus::fail_with_code(UCode::RESOURCE_EXHAUSTED, "maximum connect time exceeded")
+        }
+        _ => {
+            error!("paho error: {paho_error:?}");
+            UStatus::fail_with_code(UCode::INTERNAL, paho_error.to_string())
+        }
     }
 }
 
@@ -331,18 +374,6 @@ pub(crate) struct PahoBasedMqttClientOperations {
 }
 
 impl PahoBasedMqttClientOperations {
-    fn ustatus_from_paho_error(paho_error: &paho_mqtt::Error) -> UStatus {
-        match paho_error {
-            paho_mqtt::Error::Disconnected => {
-                UStatus::fail_with_code(UCode::UNAVAILABLE, "not connected to MQTT broker")
-            }
-            paho_mqtt::Error::TcpTlsConnectFailure => {
-                UStatus::fail_with_code(UCode::UNAVAILABLE, "failed to connect to MQTT broker")
-            }
-            _ => UStatus::fail_with_code(UCode::UNKNOWN, paho_error.to_string()),
-        }
-    }
-
     /// Creates new MQTT client.
     ///
     /// # Arguments
@@ -491,12 +522,7 @@ impl MqttClientOperations for PahoBasedMqttClientOperations {
                     Self::process_connack(user_data, response);
                 }
             })
-            .map_err(|e| {
-                UStatus::fail_with_code(
-                    UCode::INTERNAL,
-                    format!("Failed to connect to MQTT broker: {e:?}"),
-                )
-            })
+            .map_err(ustatus_from_paho_error)
     }
 
     fn is_connected(&self) -> bool {
@@ -607,7 +633,7 @@ impl MqttClientOperations for PahoBasedMqttClientOperations {
         self.inner_mqtt_client
             .publish(mqtt_message)
             .await
-            .map_err(|paho_error| Self::ustatus_from_paho_error(&paho_error))
+            .map_err(ustatus_from_paho_error)
     }
 
     async fn subscribe(&self, topic: &str, id: u16) -> Result<(), UStatus> {
@@ -634,7 +660,7 @@ impl MqttClientOperations for PahoBasedMqttClientOperations {
             // QOS 1 - Delivered and received at least once
             .subscribe_with_options(topic, paho_mqtt::QOS_1, None, subscription_properties)
             .await
-            .map_err(|paho_error| Self::ustatus_from_paho_error(&paho_error))
+            .map_err(ustatus_from_paho_error)
             .map(|_| ())
     }
 
@@ -642,14 +668,17 @@ impl MqttClientOperations for PahoBasedMqttClientOperations {
         self.inner_mqtt_client
             .unsubscribe(topic)
             .await
-            .map_err(|paho_error| Self::ustatus_from_paho_error(&paho_error))
+            .map_err(ustatus_from_paho_error)
             .map(|_| ())
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use paho_mqtt::ConnectOptions;
+    use paho_mqtt::{ConnectOptions, Properties};
+    use up_rust::UCode;
+
+    use crate::mqtt_client::ustatus_from_paho_error;
 
     use super::MqttClientOptions;
 
@@ -667,5 +696,19 @@ mod tests {
         // it is not possible to verify that the session expiry interval has been correctly set,
         // because the ConnectOptions struct does not (yet) provide access to the CONNECT packet
         // properties
+    }
+
+    #[test_case::test_case(
+        paho_mqtt::Error::TcpTlsConnectFailure => UCode::UNAVAILABLE;
+        "connect failure")]
+    #[test_case::test_case(
+        paho_mqtt::Error::Disconnected => UCode::UNAVAILABLE;
+        "disconnected")]
+    // [utest->dsn~mqtt5-transport-authorization~1]
+    #[test_case::test_case(
+        paho_mqtt::Error::ReasonCode(paho_mqtt::ReasonCode::NotAuthorized, Properties::new()) => UCode::PERMISSION_DENIED;
+        "not authorized")]
+    fn test_ustatus_from_paho_error(paho_error: paho_mqtt::Error) -> UCode {
+        ustatus_from_paho_error(paho_error).get_code()
     }
 }

--- a/src/mqtt_client.rs
+++ b/src/mqtt_client.rs
@@ -88,10 +88,12 @@ pub struct MqttClientOptions {
     pub session_expiry_interval: u32,
 
     /// The username to use for authenticating to the MQTT endpoint.
+    // [impl->dsn~mqtt5-transport-authorization~1]
     #[cfg_attr(feature = "cli", arg(long = PARAM_MQTT_USERNAME, value_name = "USERNAME", env = "MQTT_USERNAME"))]
     pub username: Option<String>,
 
     /// The password to use for authenticating to the MQTT endpoint.
+    // [impl->dsn~mqtt5-transport-authorization~1]
     #[cfg_attr(feature = "cli", arg(long = PARAM_MQTT_PASSWORD, value_name = "PWD", env = "MQTT_PASSWORD"))]
     pub password: Option<String>,
 
@@ -146,6 +148,7 @@ impl TryFrom<&MqttClientOptions> for paho_mqtt::ConnectOptions {
             // TODO: make this configiurable
             .connect_timeout(Duration::from_secs(10))
             .ssl_options(ssl_options);
+        // [impl->dsn~mqtt5-transport-authorization~1]
         if let Some(v) = options.username.as_ref() {
             connect_options_builder.user_name(v);
         }
@@ -180,10 +183,12 @@ pub struct SslOptions {
 
     /// The file in PEM format containing the public X.509 certificate chain to use for authenticating to a broker.
     /// May also contain the client’s private key.
+    // [impl->dsn~mqtt5-transport-authorization~1]
     #[cfg_attr(feature = "cli", arg(long = PARAM_MQTT_KEY_STORE_PATH, value_name = "PATH", env = "KEY_STORE_PATH", value_parser = clap::builder::PathBufValueParser::new()))]
     pub key_store_path: Option<PathBuf>,
 
     /// The file in PEM format containing the client’s private key (if not included in the Key Store).
+    // [impl->dsn~mqtt5-transport-authorization~1]
     #[cfg_attr(feature = "cli", arg(long = PARAM_MQTT_PRIVATE_KEY_PATH, value_name = "PATH", env = "PRIVATE_KEY_PATH", value_parser = clap::builder::PathBufValueParser::new()))]
     pub private_key_path: Option<PathBuf>,
 
@@ -208,6 +213,7 @@ impl TryFrom<&SslOptions> for paho_mqtt::SslOptions {
         if let Some(path) = options.trust_store_path.as_ref() {
             builder.trust_store(path)?;
         }
+        // [impl->dsn~mqtt5-transport-authorization~1]
         if let Some(path) = options.key_store_path.as_ref() {
             builder.key_store(path)?;
         }
@@ -221,6 +227,7 @@ impl TryFrom<&SslOptions> for paho_mqtt::SslOptions {
     }
 }
 
+// [impl->dsn~mapping-of-reason-codes~1]
 fn ustatus_from_paho_error(paho_error: paho_mqtt::Error) -> UStatus {
     match paho_error {
         paho_mqtt::Error::Disconnected => {
@@ -704,10 +711,37 @@ mod tests {
     #[test_case::test_case(
         paho_mqtt::Error::Disconnected => UCode::UNAVAILABLE;
         "disconnected")]
-    // [utest->dsn~mqtt5-transport-authorization~1]
+    #[test_case::test_case(
+        paho_mqtt::Error::ReasonCode(paho_mqtt::ReasonCode::BadUserNameOrPassword, Properties::new()) => UCode::UNAUTHENTICATED;
+        "bad username or password")]
     #[test_case::test_case(
         paho_mqtt::Error::ReasonCode(paho_mqtt::ReasonCode::NotAuthorized, Properties::new()) => UCode::PERMISSION_DENIED;
         "not authorized")]
+    #[test_case::test_case(
+        paho_mqtt::Error::ReasonCode(paho_mqtt::ReasonCode::ServerUnavailable, Properties::new()) => UCode::UNAVAILABLE;
+        "server unavailable")]
+    #[test_case::test_case(
+        paho_mqtt::Error::ReasonCode(paho_mqtt::ReasonCode::ServerBusy, Properties::new()) => UCode::UNAVAILABLE;
+        "server busy")]
+    #[test_case::test_case(
+        paho_mqtt::Error::ReasonCode(paho_mqtt::ReasonCode::BadAuthenticationMethod, Properties::new()) => UCode::UNAUTHENTICATED;
+        "bad authentication method")]
+    #[test_case::test_case(
+        paho_mqtt::Error::ReasonCode(paho_mqtt::ReasonCode::MessageRateTooHigh, Properties::new()) => UCode::RESOURCE_EXHAUSTED;
+        "message rate too high")]
+    #[test_case::test_case(
+        paho_mqtt::Error::ReasonCode(paho_mqtt::ReasonCode::QuotaExceeded, Properties::new()) => UCode::RESOURCE_EXHAUSTED;
+        "quota exceeded")]
+    #[test_case::test_case(
+        paho_mqtt::Error::ReasonCode(paho_mqtt::ReasonCode::ConnectionRateExceeded, Properties::new()) => UCode::RESOURCE_EXHAUSTED;
+        "connection rate exceeded")]
+    #[test_case::test_case(
+        paho_mqtt::Error::ReasonCode(paho_mqtt::ReasonCode::MaximumConnectTime, Properties::new()) => UCode::RESOURCE_EXHAUSTED;
+        "maximum connect time exceeded")]
+    #[test_case::test_case(
+        paho_mqtt::Error::ReasonCode(paho_mqtt::ReasonCode::PacketTooLarge, Properties::new()) => UCode::INTERNAL;
+        "packet too large")]
+    // [utest->dsn~mapping-of-reason-codes~1]
     fn test_ustatus_from_paho_error(paho_error: paho_mqtt::Error) -> UCode {
         ustatus_from_paho_error(paho_error).get_code()
     }

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -11,6 +11,10 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
+/*!
+This module contains the implementation of the [uProtocol Transport & Session Layer API](https://github.com/eclipse-uprotocol/up-spec/blob/v1.6.0-alpha.7/up-l1/README.adoc) for the MQTT 5.0 protocol.
+*/
+
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -196,6 +200,19 @@ mod tests {
         Some(UCode::UNAVAILABLE),
         Some(UCode::UNAVAILABLE);
         "fails if not connected to broker"
+    )]
+    // [utest->dsn~mqtt5-transport-authorization~1]
+    #[test_case(
+        create_test_message(
+            UMessageType::UMESSAGE_TYPE_PUBLISH,
+            "//vin.vehicles/A8000/2/8A50",
+            None,
+            "payload",
+        ),
+        "vin.vehicles/8000/A/2/8A50",
+        Some(UCode::PERMISSION_DENIED),
+        Some(UCode::PERMISSION_DENIED);
+        "fails if not authorized"
     )]
     #[test_case(
         create_test_message(

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -43,6 +43,8 @@ pub async fn create_up_transport_mqtt<S: Into<String>>(
     authority_name: S,
     host_broker_port: u16,
     mqtt_client_id: Option<S>,
+    username: Option<S>,
+    password: Option<S>,
 ) -> Result<Mqtt5Transport, UStatus> {
     let mqtt_client_options = MqttClientOptions {
         // tcp or ssl
@@ -53,8 +55,8 @@ pub async fn create_up_transport_mqtt<S: Into<String>>(
         max_buffered_messages: 100,
         session_expiry_interval: 3600,
         ssl_options: None,
-        username: None,
-        password: None,
+        username: username.map(|v| v.into()),
+        password: password.map(|v| v.into()),
     };
     let options = Mqtt5TransportOptions {
         mode: TransportMode::InVehicle,
@@ -70,6 +72,8 @@ pub(crate) struct MosquittoBroker {
     _broker: ContainerAsync<GenericImage>,
     port: u16,
     _config_path: TempPath,
+    _passwords_path: TempPath,
+    _acl_path: TempPath,
 }
 
 impl MosquittoBroker {
@@ -90,10 +94,15 @@ impl MosquittoBroker {
     }
 }
 
-/// Starts an Eclipse Mosquitto Docker container with given configuration options.
+/// Starts an Eclipse Mosquitto Docker container based on given configuration options.
 ///
 /// # Arguments
-/// * `config` - Optional string slice containing additional Mosquitto configuration options.
+/// * `config` - Additional Mosquitto configuration options.
+/// * `passwords` - Credentials to include in the Mosquitto configuration.
+///   If `None`, the broker will allow anonymous access.
+/// * `acl_entries` - Access Control List definitions to include in the Mosquitto configuration.
+/// * `mapped_port` - The host port to map the Mosquitto broker's container port to.
+///   If `None`, the broker will be mapped to an ephemeral port on the host.
 ///
 /// # Returns
 /// A [MosquittoBroker] instance that represents the running Mosquitto container.
@@ -102,39 +111,72 @@ impl MosquittoBroker {
 /// The given configuration will be appended to the default Mosquitto configuration which is:
 /// ```text
 /// listener 1883
-/// allow_anonymous true
 /// ```
 ///
 /// The configuration is written to a temporary file which is bind-mounted into the container.
 pub(crate) async fn start_mosquitto(
     config: Option<&str>,
+    passwords: Option<&str>,
+    acl_entries: Option<&str>,
     mapped_port: Option<u16>,
 ) -> MosquittoBroker {
     let mut mosquitto_config =
         tempfile::NamedTempFile::new().expect("failed to create Mosquitto config file");
     writeln!(mosquitto_config, "listener 1883").expect("failed to write to Mosquitto config file");
-    writeln!(mosquitto_config, "allow_anonymous true")
-        .expect("failed to write to Mosquitto config file");
+
     if let Some(configuration) = config {
         writeln!(mosquitto_config, "{configuration}")
             .expect("failed to write to Mosquitto config file");
     }
 
-    let config_path = mosquitto_config.into_temp_path();
+    let mut mosquitto_passwords =
+        tempfile::NamedTempFile::new().expect("failed to create Mosquitto password file");
+    if let Some(pwd) = passwords {
+        writeln!(mosquitto_passwords, "{pwd}").expect("failed to write to Mosquitto password file");
+        writeln!(mosquitto_config, "allow_anonymous false")
+            .expect("failed to write to Mosquitto config file");
+        writeln!(
+            mosquitto_config,
+            "password_file /mosquitto/config/passwords"
+        )
+        .expect("failed to write to Mosquitto config file");
+    } else {
+        writeln!(mosquitto_config, "allow_anonymous true")
+            .expect("failed to write to Mosquitto config file");
+    }
 
+    let mut mosquitto_acls =
+        tempfile::NamedTempFile::new().expect("failed to create Mosquitto ACL file");
+    if let Some(acls) = acl_entries {
+        writeln!(mosquitto_acls, "{acls}").expect("failed to write to Mosquitto ACL file");
+        writeln!(mosquitto_config, "acl_file /mosquitto/config/acls")
+            .expect("failed to write to Mosquitto config file");
+    }
+
+    let config_path = mosquitto_config.into_temp_path();
+    let password_path = mosquitto_passwords.into_temp_path();
+    let acl_path = mosquitto_acls.into_temp_path();
     let container_port = MOSQUITTO_CONTAINER_PORT.into();
     let container = GenericImage::new("eclipse-mosquitto", "2.0")
         .with_exposed_port(container_port)
         // mosquitto seems to write to stderr
         .with_wait_for(WaitFor::message_on_stderr(" running"))
         // uncomment next line in order capture Mosquitto log messages
-        // .with_log_consumer(
-        //     testcontainers::core::logs::consumer::logging_consumer::LoggingConsumer::new(),
-        // )
+        .with_log_consumer(
+            testcontainers::core::logs::consumer::logging_consumer::LoggingConsumer::new(),
+        )
         // use given configuration
         .with_mount(Mount::bind_mount(
             config_path.display().to_string(),
             "/mosquitto/config/mosquitto.conf",
+        ))
+        .with_mount(Mount::bind_mount(
+            password_path.display().to_string(),
+            "/mosquitto/config/passwords",
+        ))
+        .with_mount(Mount::bind_mount(
+            acl_path.display().to_string(),
+            "/mosquitto/config/acls",
         ))
         .with_mapped_port(mapped_port.unwrap_or_default(), container_port)
         .start()
@@ -150,5 +192,7 @@ pub(crate) async fn start_mosquitto(
         _broker: container,
         port: host_port,
         _config_path: config_path,
+        _passwords_path: password_path,
+        _acl_path: acl_path,
     }
 }

--- a/tests/publish_subscribe.rs
+++ b/tests/publish_subscribe.rs
@@ -15,9 +15,18 @@ use std::{str::FromStr, sync::Arc, time::Duration};
 
 use log::debug;
 use serial_test::serial;
-use up_rust::{MockUListener, UMessageBuilder, UTransport, UUri};
+use up_rust::{MockUListener, UCode, UMessageBuilder, UTransport, UUri};
 
 mod common;
+
+// User credentials to be used with the Mosquitto broker
+// created using https://dmelo.eu/blog/mosquitto_passwd_gen/
+// username: publisher, password: uprotocol
+// username: subscriber, password: uprotocol
+const PASSWD_FILE: &str = r#"
+    publisher:$7$101$njCnRQhFsQbDh5NF$pWuZpNcTNwM1tbDePb+UTww3Y6cL5jfC0tXVAUvRTc5wTDjE9PnzTQmyxW/1RA86rHvtXywrqlJS2cWyELeI1Q==
+    subscriber:$7$101$zACO8Nh9VM+YjQJR$hZZSQ+Qlp1Gvr4Fau00dQTyiNmBAkHd/uE2Ucd1uZ1ST870Y5WH5cQ33/VnbfJgURePpMBSBkTdaQyqMCIe5GQ==
+  "#;
 
 const MOSQUITTO_CONFIG_W_PERSISTENCE: &str = r#"
 persistence true
@@ -34,7 +43,8 @@ async fn test_publish_and_subscribe_succeeds_after_reconnect(mosquitto_config: O
     let _ = env_logger::try_init();
 
     // fixture
-    let mosquitto = common::start_mosquitto(mosquitto_config, Some(15000)).await;
+    let mosquitto =
+        common::start_mosquitto(mosquitto_config, Some(PASSWD_FILE), None, Some(15000)).await;
     let topic = UUri::from_str("//publisher/A8000/2/8A50").expect("invalid topic URI");
     let message_to_send = UMessageBuilder::publish(topic)
         .build_with_payload(
@@ -57,6 +67,8 @@ async fn test_publish_and_subscribe_succeeds_after_reconnect(mosquitto_config: O
         "subscriber",
         mosquitto.port(),
         Some("subscriber_client_id"),
+        Some("subscriber"),
+        Some("uprotocol"),
     )
     .await
     .map(Arc::new)
@@ -76,6 +88,8 @@ async fn test_publish_and_subscribe_succeeds_after_reconnect(mosquitto_config: O
         "publisher",
         mosquitto.port(),
         Some("publisher_client_id"),
+        Some("publisher"),
+        Some("uprotocol"),
     )
     .await
     .map(Arc::new)
@@ -140,4 +154,94 @@ async fn test_publish_and_subscribe_succeeds_after_reconnect(mosquitto_config: O
         .is_ok(),
         "did not receive second message before timeout"
     );
+}
+
+#[tokio::test]
+#[cfg_attr(not(docker_available), ignore)]
+// This test requires Docker to run the Mosquitto MQTT broker.
+async fn test_connect_fails_for_wrong_credentials() {
+    let _ = env_logger::try_init();
+
+    // fixture
+    let mosquitto = common::start_mosquitto(None, Some(PASSWD_FILE), None, None).await;
+    let port = mosquitto.port();
+
+    let publisher = common::create_up_transport_mqtt(
+        "publisher",
+        port,
+        None,
+        Some("publisher"),
+        Some("wrong_password"),
+    )
+    .await
+    .expect("failed to create MQTT5 transport");
+
+    assert!(
+        publisher.connect().await.is_err_and(|err| {
+            debug!("connect attempt failed: {err:?}");
+            // this is not generally required by the MQTT 5 spec but we know that
+            // the Mosquitto broker returns a CONNACK with reason code 135 instead
+            // of simply closing the connection
+            err.get_code() == UCode::PERMISSION_DENIED
+        }),
+        "expected connection to fail due to wrong credentials"
+    );
+
+    publisher.shutdown().await;
+}
+
+#[tokio::test]
+#[cfg_attr(not(docker_available), ignore)]
+// This test requires Docker to run the Mosquitto MQTT broker.
+async fn test_publish_fails_if_unauthorized() {
+    let _ = env_logger::try_init();
+
+    // fixture
+    let acl_file = r#"
+        user publisher
+        topic write publisher/8000/A/#
+    "#;
+    let mosquitto = common::start_mosquitto(None, Some(PASSWD_FILE), Some(acl_file), None).await;
+
+    let publisher = common::create_up_transport_mqtt(
+        "publisher",
+        mosquitto.port(),
+        None,
+        Some("publisher"),
+        Some("uprotocol"),
+    )
+    .await
+    .expect("failed to create transport at sending end");
+
+    publisher
+        .connect()
+        .await
+        .expect("failed to connect publisher to broker");
+
+    let authorized_source = UUri::from_str("/A8000/2/8A50").unwrap();
+    assert!(
+        publisher
+            .send(UMessageBuilder::publish(authorized_source).build().unwrap())
+            .await
+            .is_ok(),
+        "expected publishing to topic to succeed with correct authority"
+    );
+
+    let unauthorized_source = UUri::from_str("/100/1/B500").unwrap();
+    assert!(
+        publisher
+            .send(
+                UMessageBuilder::publish(unauthorized_source)
+                    .build()
+                    .unwrap()
+            )
+            .await
+            .is_err_and(|err| {
+                debug!("failed to publish message: {err:?}");
+                err.get_code() == UCode::PERMISSION_DENIED
+            }),
+        "expected publishing to topic to fail due to missing authority"
+    );
+
+    publisher.shutdown().await;
 }


### PR DESCRIPTION
Added test cases for making sure that the MQTT 5 transport uses given credentials and ACLs to enforce authorization.

Also added missing documentation and split out design decisions into separate document.

Fixes #77