### PR TITLE
Update astral tokio tar to 0.6.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,9 +78,9 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "astral-tokio-tar"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ce73b17c62717c4b6a9af10b43e87c578b0cac27e00666d48304d3b7d2c0693"
+checksum = "cb50a7aae84a03bf55b067832bc376f4961b790c97e64d3eacee97d389b90277"
 dependencies = [
  "filetime",
  "futures-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,8 +57,8 @@ up-rust = { version = "0.9", default-features = false }
 testcontainers = { version = "0.27.3", default-features = false, features = ["blocking"] }
 
 [dev-dependencies]
-# https://rustsec.org/advisories/RUSTSEC-2026-0112
-astral-tokio-tar = { version = "0.6.1" }
+# https://rustsec.org/advisories/RUSTSEC-2026-0145
+astral-tokio-tar = { version = "0.6.2" }
 env_logger = { version = "0.11.10" }
 mockall = { version = "0.14.0" }
 serial_test = { version = "3.2.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ default = ["cli"]
 cli = ["clap"]
 
 [dependencies]
-async-channel = { version = "2.0.0" }
+async-channel = { version = "2.5" }
 async-trait = { version = "0.1" }
 backon = { version = "1.6", default-features = false, features = ["tokio-sleep"] }
 bytes = { version = "1.11.1" }


### PR DESCRIPTION
Updated dev-dependency astral-tokio-tar to version 0.6.2 to address
security advisory RUSTSEC-2026-0145.