### PR TITLE
Reduce permissions for GitHub Actions workflows

### DIFF
--- a/.github/workflows/check-dependencies.yaml
+++ b/.github/workflows/check-dependencies.yaml
@@ -29,12 +29,18 @@ env:
   RUSTFLAGS: -Dwarnings
   CARGO_TERM_COLOR: always
 
+permissions: {}
+
 jobs:
   deps:
     name: "Check 3rd party licenses"
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # Required by the run-eclipse-dash action for uploading results of the license check
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      with:
+        persist-credentials: false
     - name: Determine 3rd party dependencies
       working-directory: ${{github.workspace}}
       run: |

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -17,156 +17,176 @@
 name: Cargo check and clippy
 
 on:
-  push:
-    branches: 
-      - main
-  pull_request:
-    paths:
-      - "examples/**"
-      - "src/**"
-      - "tests/**"
-      - "Cargo.*"
-  workflow_call:
-    outputs:
-      test_results_url:
-        description: "URL of the test results artifact"
-        value: ${{ jobs.test.outputs.test_results_url }}
-  workflow_dispatch:
+    push:
+        branches:
+            - main
+    pull_request:
+        paths:
+            - "examples/**"
+            - "src/**"
+            - "tests/**"
+            - "Cargo.*"
+    workflow_call:
+        outputs:
+            test_results_url:
+                description: "URL of the test results artifact"
+                value: ${{ jobs.test.outputs.test_results_url }}
+    workflow_dispatch:
 
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}
-  cancel-in-progress: true
+    group: ${{ github.ref }}-${{ github.workflow }}
+    cancel-in-progress: true
 
 env:
-  RUST_TOOLCHAIN: ${{ vars.RUST_TOOLCHAIN || 'stable' }}
-  RUSTFLAGS: -Dwarnings
-  CARGO_TERM_COLOR: always
+    RUST_TOOLCHAIN: ${{ vars.RUST_TOOLCHAIN || 'stable' }}
+    RUSTFLAGS: -Dwarnings
+    CARGO_TERM_COLOR: always
+
+permissions: {}
 
 jobs:
-  check:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      with:
-        submodules: "recursive"
-    - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
-      with: 
-        toolchain: ${{ env.RUST_TOOLCHAIN }}
-    - name: Run cargo check
-      run: |
-        cargo check --workspace --all-targets --all-features
+    check:
+        name: "Perform basic checks with cargo check"
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+              with:
+                  persist-credentials: false
+                  submodules: "recursive"
+            - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
+              with:
+                  toolchain: ${{ env.RUST_TOOLCHAIN }}
+            - name: Run cargo check
+              run: |
+                  cargo check --workspace --all-targets --all-features
 
-  fmt:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
-        with: 
-          toolchain: ${{ env.RUST_TOOLCHAIN }}
-          components: rustfmt
-      - name: Run cargo fmt
-        run: |
-          cargo fmt --all --check
+    fmt:
+        name: "Check code formatting with cargo fmt"
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+              with:
+                  persist-credentials: false
+            - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
+              with:
+                  toolchain: ${{ env.RUST_TOOLCHAIN }}
+                  components: rustfmt
+            - name: Run cargo fmt
+              run: |
+                  cargo fmt --all --check
 
-  clippy:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          submodules: "recursive"
-      - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
-        with: 
-          toolchain: ${{ env.RUST_TOOLCHAIN }}
-          components: clippy
-      - name: Run cargo clippy
-        run: |
-          cargo clippy --version
-          cargo clippy --all-targets --all-features --no-deps -- -W warnings -D warnings
+    clippy:
+        name: "Check code with cargo clippy"
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+              with:
+                  persist-credentials: false
+                  submodules: "recursive"
+            - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
+              with:
+                  toolchain: ${{ env.RUST_TOOLCHAIN }}
+                  components: clippy
+            - name: Run cargo clippy
+              run: |
+                  cargo clippy --version
+                  cargo clippy --all-targets --all-features --no-deps -- -W warnings -D warnings
 
-  docu:
-    runs-on: ubuntu-latest
-    env:
-      RUSTDOCFLAGS: -Dwarnings
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          submodules: "recursive"
-      - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
-        with: 
-          toolchain: ${{ env.RUST_TOOLCHAIN }}
-      - name: Run rustdoc
-        run: |
-          cargo doc --no-deps --all-features
+    docu:
+        name: "Create documentation with cargo doc"
+        runs-on: ubuntu-latest
+        env:
+            RUSTDOCFLAGS: -Dwarnings
+        steps:
+            - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+              with:
+                  persist-credentials: false
+                  submodules: "recursive"
+            - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
+              with:
+                  toolchain: ${{ env.RUST_TOOLCHAIN }}
+            - name: Run rustdoc
+              run: |
+                  cargo doc --no-deps --all-features
 
-  check-links:
-    # check links contained in markdown and source code files
-    # sadly, lychee does not (yet) support checking links in Asciidoc files
-    # https://github.com/lycheeverse/lychee/issues/291
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          submodules: "recursive"
-      - name: Restore lychee cache
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: .lycheecache
-          key: cache-lychee-${{ github.sha }}
-          restore-keys: cache-lychee-
-      
-      - name: Run lychee
-        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
-        with:
-          args: |
-            --cache --max-cache-age 1d --verbose --no-progress --exclude-path './target/' --exclude-path './up-spec/' -- './**/*.md' './**/*.rs' './**/*.toml' './**/*.yaml'
+    check-links:
+        name: "Check links in markdown and source code files"
+        # check links contained in markdown and source code files
+        # sadly, lychee does not (yet) support checking links in Asciidoc files
+        # https://github.com/lycheeverse/lychee/issues/291
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+              with:
+                  persist-credentials: false
+                  submodules: "recursive"
+            - name: Restore lychee cache
+              uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+              with:
+                  path: .lycheecache
+                  key: cache-lychee-${{ github.sha }}
+                  restore-keys: cache-lychee-
 
-  feature-check:
-    # Comprehensive check for feature flag combinations, excluding development dependencies
-    needs: check
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          submodules: "recursive"
-      - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
-        with: 
-          toolchain: ${{ env.RUST_TOOLCHAIN }}
-      - uses: taiki-e/install-action@9e1e5806d4a4822de933115878265be9aaa786d9 # v2.82.2
-        with:
-          tool: cargo-hack
-      - name: Run cargo hack powerset
-        run: |
-          cargo hack check --feature-powerset --no-dev-deps
+            - name: Run lychee
+              uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
+              with:
+                  args: |
+                      --cache --max-cache-age 1d --verbose --no-progress --exclude-path './target/' --exclude-path './up-spec/' -- './**/*.md' './**/*.rs' './**/*.toml' './**/*.yaml'
 
-  test:
-    # Subset of feature-combos, on only one OS - more complete testing in test-featurematrix.yaml
-    outputs:
-      test_results_url: ${{ steps.test_results.outputs.artifact-url }}
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        feature-flags: ["", "--no-default-features", "--all-features"]
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          submodules: "recursive"
-      - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
-        with: 
-          toolchain: ${{ env.RUST_TOOLCHAIN }}
-      - name: Run lib tests
-        run: |
-          mkdir -p ${GITHUB_WORKSPACE}/target
-          RUSTC_BOOTSTRAP=1 cargo test --no-fail-fast --all-targets ${{ matrix.feature-flags }} -- -Z unstable-options --format junit --report-time > ${GITHUB_WORKSPACE}/target/lib-test-results.xml
-      - name: Run doc tests
-        run: |
-          RUSTC_BOOTSTRAP=1 cargo test --no-fail-fast --doc ${{ matrix.feature-flags }} -- -Z unstable-options --format junit --report-time > ${GITHUB_WORKSPACE}/target/doc-test-results.xml
+    feature-check:
+        name: "Check feature flag combinations"
+        # Comprehensive check for feature flag combinations, excluding development dependencies
+        needs: check
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+              with:
+                  persist-credentials: false
+                  submodules: "recursive"
+            - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
+              with:
+                  toolchain: ${{ env.RUST_TOOLCHAIN }}
+            - uses: taiki-e/install-action@9e1e5806d4a4822de933115878265be9aaa786d9 # v2.82.2
+              with:
+                  tool: cargo-hack
+            - name: Run cargo hack powerset
+              run: |
+                  cargo hack check --feature-powerset --no-dev-deps
 
-      - name: Upload all-features test results artifact
-        id: test_results
-        if: matrix.feature-flags == '--all-features'
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: test-results
-          # include all test result files
-          path: target/*-results.xml
-  
+    test:
+        name: "Run tests with cargo test"
+        # Run tests for a subset of feature combinations, on only one OS - more complete testing in test-featurematrix.yaml
+        needs: feature-check
+        # Subset of feature-combos, on only one OS - more complete testing in test-featurematrix.yaml
+        outputs:
+            test_results_url: ${{ steps.test_results.outputs.artifact-url }}
+        runs-on: ubuntu-latest
+        strategy:
+            matrix:
+                feature-flags: ["", "--no-default-features", "--all-features"]
+        permissions:
+            contents: write # for uploading the test results artifact
+        steps:
+            - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+              with:
+                  persist-credentials: false
+                  submodules: "recursive"
+            - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
+              with:
+                  toolchain: ${{ env.RUST_TOOLCHAIN }}
+            - name: Run lib tests
+              run: |
+                  mkdir -p ${GITHUB_WORKSPACE}/target
+                  RUSTC_BOOTSTRAP=1 cargo test --no-fail-fast --all-targets ${{ matrix.feature-flags }} -- -Z unstable-options --format junit --report-time > ${GITHUB_WORKSPACE}/target/lib-test-results.xml
+            - name: Run doc tests
+              run: |
+                  RUSTC_BOOTSTRAP=1 cargo test --no-fail-fast --doc ${{ matrix.feature-flags }} -- -Z unstable-options --format junit --report-time > ${GITHUB_WORKSPACE}/target/doc-test-results.xml
+
+            - name: Upload all-features test results artifact
+              id: test_results
+              if: matrix.feature-flags == '--all-features'
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+              with:
+                  name: test-results
+                  # include all test result files
+                  path: target/*-results.xml

--- a/.github/workflows/deny.yaml
+++ b/.github/workflows/deny.yaml
@@ -16,23 +16,26 @@
 name: Deny
 
 on:
-  pull_request:
-    paths:
-      - "Cargo.toml"
-      - "Cargo.lock"
-  workflow_dispatch:
+    pull_request:
+        paths:
+            - "Cargo.toml"
+            - "Cargo.lock"
+    workflow_dispatch:
 
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}
-  cancel-in-progress: true
+    group: ${{ github.ref }}-${{ github.workflow }}
+    cancel-in-progress: true
 
 env:
-  RUST_TOOLCHAIN: ${{ vars.RUST_TOOLCHAIN || 'stable' }}
-  RUSTFLAGS: -Dwarnings
-  CARGO_TERM_COLOR: always
+    RUST_TOOLCHAIN: ${{ vars.RUST_TOOLCHAIN || 'stable' }}
+    RUSTFLAGS: -Dwarnings
+    CARGO_TERM_COLOR: always
+
+permissions: {}
 
 jobs:
-  deny:
-    uses: eclipse-uprotocol/ci-cd/.github/workflows/rust-deny-check.yaml@fcaf488b5d152c290a3a8dca2463a5c1dec65acd
-    with:
-      arguments: --all-features --locked --exclude-dev
+    deny:
+        name: "Check for CVEs and other issues with cargo-deny"
+        uses: eclipse-uprotocol/ci-cd/.github/workflows/rust-deny-check.yaml@fcaf488b5d152c290a3a8dca2463a5c1dec65acd
+        with:
+            arguments: --all-features --locked --exclude-dev

--- a/.github/workflows/latest-up-spec-compatibility.yaml
+++ b/.github/workflows/latest-up-spec-compatibility.yaml
@@ -31,12 +31,19 @@ env:
   RUSTFLAGS: -Dwarnings
   CARGO_TERM_COLOR: always
 
+permissions: {}
+
 jobs:
   requirements-tracing:
+    name: "Verify compatibility with latest uProtocol Spec"
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # Required by the run-oft action for uploading requirements tracing results
+
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          persist-credentials: false
           submodules: "recursive"
       - name: Fast-Forward to HEAD revision of uProtocol Spec main branch
         run: |

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -17,37 +17,43 @@
 name: Nightly
 
 on:
-  schedule:
-    - cron: '0 3 * * *'
-  workflow_dispatch:
+    schedule:
+        - cron: "0 3 * * *"
+    workflow_dispatch:
 
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}
-  cancel-in-progress: true
+    group: ${{ github.ref }}-${{ github.workflow }}
+    cancel-in-progress: true
+
+permissions: {}
 
 jobs:
-  check-msrv:
-    uses: eclipse-uprotocol/ci-cd/.github/workflows/rust-verify-msrv.yaml@fcaf488b5d152c290a3a8dca2463a5c1dec65acd
+    check-msrv:
+        uses: eclipse-uprotocol/ci-cd/.github/workflows/rust-verify-msrv.yaml@fcaf488b5d152c290a3a8dca2463a5c1dec65acd
 
-  check-latest-deps:
-    uses: eclipse-uprotocol/ci-cd/.github/workflows/rust-verify-latest-deps.yaml@fcaf488b5d152c290a3a8dca2463a5c1dec65acd
+    check-latest-deps:
+        uses: eclipse-uprotocol/ci-cd/.github/workflows/rust-verify-latest-deps.yaml@fcaf488b5d152c290a3a8dca2463a5c1dec65acd
 
-  deny:
-    uses: eclipse-uprotocol/ci-cd/.github/workflows/rust-deny-check.yaml@fcaf488b5d152c290a3a8dca2463a5c1dec65acd
-    with:
-      arguments: --all-features --locked --exclude-dev
+    deny:
+        uses: eclipse-uprotocol/ci-cd/.github/workflows/rust-deny-check.yaml@fcaf488b5d152c290a3a8dca2463a5c1dec65acd
+        with:
+            arguments: --all-features --locked --exclude-dev
 
-  test-all-features:
-    uses: eclipse-uprotocol/ci-cd/.github/workflows/rust-test-featurematrix.yaml@fcaf488b5d152c290a3a8dca2463a5c1dec65acd
+    test-all-features:
+        uses: eclipse-uprotocol/ci-cd/.github/workflows/rust-test-featurematrix.yaml@fcaf488b5d152c290a3a8dca2463a5c1dec65acd
 
-  x-build:
-    # The jury is still out on whether this actually adds any value, besides simply being possible...
-    uses: eclipse-uprotocol/ci-cd/.github/workflows/rust-x-build.yaml@fcaf488b5d152c290a3a8dca2463a5c1dec65acd
+    x-build:
+        # The jury is still out on whether this actually adds any value, besides simply being possible...
+        uses: eclipse-uprotocol/ci-cd/.github/workflows/rust-x-build.yaml@fcaf488b5d152c290a3a8dca2463a5c1dec65acd
 
-  coverage:
-    uses: eclipse-uprotocol/ci-cd/.github/workflows/rust-coverage.yaml@fcaf488b5d152c290a3a8dca2463a5c1dec65acd
+    coverage:
+        permissions:
+            contents: write # required for uploading coverage results as workflow artifacts
+        uses: eclipse-uprotocol/ci-cd/.github/workflows/rust-coverage.yaml@fcaf488b5d152c290a3a8dca2463a5c1dec65acd
 
-  current-spec-compliance:
-    uses: eclipse-uprotocol/ci-cd/.github/workflows/requirements-tracing.yaml@fcaf488b5d152c290a3a8dca2463a5c1dec65acd
-    with:
-      env-file-suffix: "oft-current"
+    current-spec-compliance:
+        permissions:
+            contents: write # required for uploading tracing results as workflow artifacts
+        uses: eclipse-uprotocol/ci-cd/.github/workflows/requirements-tracing.yaml@fcaf488b5d152c290a3a8dca2463a5c1dec65acd
+        with:
+            env-file-suffix: "oft-current"


### PR DESCRIPTION
Only define permissions for the workflows that need them, and set them to read-only where possible. This reduces the attack surface in case of a compromised workflow.